### PR TITLE
Change AST

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -199,6 +199,7 @@ export interface SvelteName extends BaseNode {
         | SvelteStyleElement
         | SvelteAttribute
         | SvelteMemberExpressionName
+        | SvelteDirectiveKey
 }
 
 /** Nodes that may be used in component names. The component names separated by dots. */
@@ -414,7 +415,7 @@ export type SvelteDirective =
     | SvelteTransitionDirective
 export interface SvelteDirectiveKey extends BaseNode {
     type: "SvelteDirectiveKey"
-    name: ESTree.Identifier
+    name: ESTree.Identifier | SvelteName
     modifiers: string[]
     parent: SvelteDirective
 }

--- a/src/context/let-directive-collection.ts
+++ b/src/context/let-directive-collection.ts
@@ -1,11 +1,11 @@
-import type { SvelteLetDirective, SvelteNode } from "../ast"
+import type { SvelteLetDirective, SvelteName, SvelteNode } from "../ast"
 import type * as ESTree from "estree"
 import type { ScriptLetCallback, ScriptLetCallbackOption } from "./script-let"
 
 /** A class that collects pattern nodes for Let directives. */
 export class LetDirectiveCollection {
     private readonly list: {
-        pattern: ESTree.Pattern
+        pattern: ESTree.Pattern | SvelteName
         directive: SvelteLetDirective
         typing: string
         callbacks: ScriptLetCallback<ESTree.Pattern>[]
@@ -15,7 +15,7 @@ export class LetDirectiveCollection {
         return this.list.length === 0
     }
 
-    public getLetParams(): ESTree.Pattern[] {
+    public getLetParams(): (ESTree.Pattern | SvelteName)[] {
         return this.list.map((d) => d.pattern)
     }
 
@@ -43,7 +43,7 @@ export class LetDirectiveCollection {
     }
 
     public addPattern(
-        pattern: ESTree.Pattern,
+        pattern: ESTree.Pattern | SvelteName,
         directive: SvelteLetDirective,
         typing: string,
         ...callbacks: ScriptLetCallback<ESTree.Pattern>[]

--- a/src/context/script-let.ts
+++ b/src/context/script-let.ts
@@ -6,6 +6,7 @@ import type {
     Locations,
     SvelteEachBlock,
     SvelteIfBlock,
+    SvelteName,
     SvelteNode,
     Token,
 } from "../ast"
@@ -48,6 +49,11 @@ function getNodeRange(
         | {
               start: number
               end: number
+              leadingComments?: Comment[]
+              trailingComments?: Comment[]
+          }
+        | {
+              range: [number, number]
               leadingComments?: Comment[]
               trailingComments?: Comment[]
           },
@@ -98,7 +104,7 @@ export class ScriptLetContext {
     }
 
     public addExpression<E extends ESTree.Expression>(
-        expression: E,
+        expression: E | SvelteName,
         parent: SvelteNode,
         typing?: string | null,
         ...callbacks: ScriptLetCallback<E>[]
@@ -300,7 +306,7 @@ export class ScriptLetContext {
 
     public nestBlock(
         block: SvelteNode,
-        params: ESTree.Pattern[],
+        params: (ESTree.Pattern | SvelteName)[],
         parents: SvelteNode[],
         callback: (
             nodes: ESTree.Pattern[],
@@ -311,7 +317,7 @@ export class ScriptLetContext {
 
     public nestBlock(
         block: SvelteNode,
-        params?: ESTree.Pattern[],
+        params?: (ESTree.Pattern | SvelteName)[],
         parents?: SvelteNode[],
         callback?: (
             nodes: ESTree.Pattern[],

--- a/tests/fixtures/parser/ast/blog/write-less-code01-output.json
+++ b/tests/fixtures/parser/ast/blog/write-less-code01-output.json
@@ -326,7 +326,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   70,
@@ -530,7 +530,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   107,

--- a/tests/fixtures/parser/ast/class-directive01-output.json
+++ b/tests/fixtures/parser/ast/class-directive01-output.json
@@ -270,7 +270,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "bar",
                 "range": [
                   66,
@@ -434,7 +434,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "foo",
                 "range": [
                   94,

--- a/tests/fixtures/parser/ast/docs/component-format/01-script/03-$-marks-a-statement-as-reactive/02-output.json
+++ b/tests/fixtures/parser/ast/docs/component-format/01-script/03-$-marks-a-statement-as-reactive/02-output.json
@@ -616,7 +616,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   154,
@@ -840,7 +840,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   208,

--- a/tests/fixtures/parser/ast/docs/template-syntax/04-comments/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/04-comments/02-output.json
@@ -67,7 +67,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   50,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "eventname",
                 "range": [
                   8,
@@ -179,7 +179,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "eventname",
                 "range": [
                   39,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/02-output.json
@@ -345,7 +345,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   96,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/03-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/03-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   11,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/04-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/04-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "submit",
                 "range": [
                   9,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/05-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/05-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   11,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/06-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/01-on-eventname/06-output.json
@@ -512,7 +512,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   150,
@@ -584,7 +584,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   171,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "property",
                 "range": [
                   10,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/02-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   12,
@@ -179,7 +179,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   41,
@@ -399,7 +399,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "checked",
                 "range": [
                   95,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/03-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/03-output.json
@@ -67,7 +67,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   42,
@@ -215,7 +215,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   69,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/04-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/04-output.json
@@ -87,7 +87,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   26,
@@ -291,7 +291,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   64,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/05-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/05-output.json
@@ -254,7 +254,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "files",
                 "range": [
                   91,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/06-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/06-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   13,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/07-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/07-output.json
@@ -68,7 +68,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   22,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/08-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/08-output.json
@@ -68,7 +68,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   22,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/09-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/09-output.json
@@ -87,7 +87,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "innerHTML",
                 "range": [
                   33,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/10-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/10-output.json
@@ -105,7 +105,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "duration",
                 "range": [
                   25,
@@ -177,7 +177,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "buffered",
                 "range": [
                   40,
@@ -249,7 +249,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "played",
                 "range": [
                   55,
@@ -321,7 +321,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "seekable",
                 "range": [
                   68,
@@ -393,7 +393,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "seeking",
                 "range": [
                   83,
@@ -465,7 +465,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "ended",
                 "range": [
                   97,
@@ -537,7 +537,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "currentTime",
                 "range": [
                   109,
@@ -609,7 +609,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "playbackRate",
                 "range": [
                   127,
@@ -681,7 +681,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "paused",
                 "range": [
                   146,
@@ -753,7 +753,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "volume",
                 "range": [
                   159,
@@ -825,7 +825,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "muted",
                 "range": [
                   172,
@@ -897,7 +897,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "videoWidth",
                 "range": [
                   184,
@@ -969,7 +969,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "videoHeight",
                 "range": [
                   201,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/11-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/02-bind-property/11-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "offsetWidth",
                 "range": [
                   11,
@@ -103,7 +103,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "offsetHeight",
                 "range": [
                   37,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/03-bind-group/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/03-bind-group/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   12,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/03-bind-group/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/03-bind-group/02-output.json
@@ -361,7 +361,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   143,
@@ -621,7 +621,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   200,
@@ -881,7 +881,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   263,
@@ -1177,7 +1177,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   377,
@@ -1437,7 +1437,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   436,
@@ -1697,7 +1697,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   496,
@@ -1957,7 +1957,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "group",
                 "range": [
                   557,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/04-bind-this/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/04-bind-this/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   10,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/04-bind-this/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/04-bind-this/02-output.json
@@ -587,7 +587,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   176,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/05-class-name/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/05-class-name/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "name",
                 "range": [
                   11,
@@ -179,7 +179,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "name",
                 "range": [
                   37,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/05-class-name/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/05-class-name/02-output.json
@@ -307,7 +307,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "active",
                 "range": [
                   89,
@@ -526,7 +526,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "active",
                 "range": [
                   177,
@@ -745,7 +745,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "active",
                 "range": [
                   254,
@@ -817,7 +817,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "inactive",
                 "range": [
                   267,
@@ -908,7 +908,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "isAdmin",
                 "range": [
                   292,

--- a/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/07-transition-fn/06-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/11-element-directives/07-transition-fn/06-output.json
@@ -244,7 +244,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "introstart",
                     "range": [
                       71,
@@ -375,7 +375,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "outrostart",
                     "range": [
                       122,
@@ -506,7 +506,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "introend",
                     "range": [
                       173,
@@ -637,7 +637,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "outroend",
                     "range": [
                       220,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/01-on-eventname/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/01-on-eventname/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "eventname",
                 "range": [
                   11,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/01-on-eventname/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/01-on-eventname/02-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "whatever",
                 "range": [
                   18,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/01-on-eventname/03-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/01-on-eventname/03-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "whatever",
                 "range": [
                   18,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/02-bind-property/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/02-bind-property/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "property",
                 "range": [
                   13,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/02-bind-property/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/02-bind-property/02-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   13,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/03-bind-this/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/03-bind-this/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   13,

--- a/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/03-bind-this/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/12-component-directives/03-bind-this/02-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   19,
@@ -179,7 +179,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   45,

--- a/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/01-output.json
@@ -657,7 +657,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "prop",
                 "range": [
                   171,

--- a/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/01-scope-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/01-scope-output.json
@@ -736,7 +736,7 @@
                           "key": {
                             "type": "SvelteDirectiveKey",
                             "name": {
-                              "type": "Identifier",
+                              "type": "SvelteName",
                               "name": "prop",
                               "range": [
                                 171,

--- a/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/02-output.json
@@ -956,7 +956,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "item",
                     "range": [
                       226,

--- a/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/02-scope-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/13-slot/03-slot-let-name-value/02-scope-output.json
@@ -774,7 +774,7 @@
                           "key": {
                             "type": "SvelteDirectiveKey",
                             "name": {
-                              "type": "Identifier",
+                              "type": "SvelteName",
                               "name": "item",
                               "range": [
                                 226,

--- a/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "event",
                 "range": [
                   18,

--- a/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/02-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "prop",
                 "range": [
                   20,

--- a/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/03-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/03-output.json
@@ -374,7 +374,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "keydown",
                 "range": [
                   115,

--- a/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/04-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/16-svelte-window/04-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "scrollY",
                 "range": [
                   20,

--- a/tests/fixtures/parser/ast/docs/template-syntax/17-svelte-body/01-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/17-svelte-body/01-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "event",
                 "range": [
                   16,

--- a/tests/fixtures/parser/ast/docs/template-syntax/17-svelte-body/02-output.json
+++ b/tests/fixtures/parser/ast/docs/template-syntax/17-svelte-body/02-output.json
@@ -31,7 +31,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseenter",
                 "range": [
                   17,
@@ -103,7 +103,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseleave",
                 "range": [
                   51,

--- a/tests/fixtures/parser/ast/hello/hello-world04-output.json
+++ b/tests/fixtures/parser/ast/hello/hello-world04-output.json
@@ -326,7 +326,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   91,

--- a/tests/fixtures/parser/ast/hello/hello-world05-output.json
+++ b/tests/fixtures/parser/ast/hello/hello-world05-output.json
@@ -3144,7 +3144,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       1287,

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind01-input.svelte
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind01-input.svelte
@@ -1,0 +1,4 @@
+<script>
+let value = ''
+</script>
+<input bind:va.lue="{value}"/>

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind01-output.json
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind01-output.json
@@ -1,0 +1,768 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteScriptElement",
+      "name": {
+        "type": "SvelteName",
+        "name": "script",
+        "range": [
+          1,
+          7
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [],
+        "selfClosing": false,
+        "range": [
+          0,
+          8
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      },
+      "body": [
+        {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              },
+              "init": {
+                "type": "Literal",
+                "raw": "''",
+                "value": "",
+                "range": [
+                  21,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              },
+              "range": [
+                13,
+                23
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 14
+                }
+              }
+            }
+          ],
+          "range": [
+            9,
+            23
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 14
+            }
+          }
+        }
+      ],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          24,
+          33
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 9
+          }
+        }
+      },
+      "range": [
+        0,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "SvelteText",
+      "value": "\n",
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 4,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "SvelteElement",
+      "kind": "html",
+      "name": {
+        "type": "SvelteName",
+        "name": "input",
+        "range": [
+          35,
+          40
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 6
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [
+          {
+            "type": "SvelteDirective",
+            "kind": "Binding",
+            "key": {
+              "type": "SvelteDirectiveKey",
+              "name": {
+                "type": "SvelteName",
+                "name": "va.lue",
+                "range": [
+                  46,
+                  52
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                }
+              },
+              "modifiers": [],
+              "range": [
+                41,
+                52
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 7
+                },
+                "end": {
+                  "line": 4,
+                  "column": 18
+                }
+              }
+            },
+            "expression": {
+              "type": "Identifier",
+              "name": "value",
+              "range": [
+                55,
+                60
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 21
+                },
+                "end": {
+                  "line": 4,
+                  "column": 26
+                }
+              }
+            },
+            "range": [
+              41,
+              62
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 7
+              },
+              "end": {
+                "line": 4,
+                "column": 28
+              }
+            }
+          }
+        ],
+        "selfClosing": true,
+        "range": [
+          34,
+          64
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 30
+          }
+        }
+      },
+      "children": [],
+      "endTag": null,
+      "range": [
+        34,
+        64
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        1,
+        7
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        7,
+        8
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "let",
+      "range": [
+        9,
+        12
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "value",
+      "range": [
+        13,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 4
+        },
+        "end": {
+          "line": 2,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        19,
+        20
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 10
+        },
+        "end": {
+          "line": 2,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "String",
+      "value": "''",
+      "range": [
+        21,
+        23
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 12
+        },
+        "end": {
+          "line": 2,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        24,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        25,
+        26
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        26,
+        32
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        32,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 8
+        },
+        "end": {
+          "line": 3,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n",
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 4,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        34,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "input",
+      "range": [
+        35,
+        40
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 1
+        },
+        "end": {
+          "line": 4,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "bind",
+      "range": [
+        41,
+        45
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 7
+        },
+        "end": {
+          "line": 4,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        45,
+        46
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 11
+        },
+        "end": {
+          "line": 4,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "va.lue",
+      "range": [
+        46,
+        52
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 12
+        },
+        "end": {
+          "line": 4,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        52,
+        53
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 18
+        },
+        "end": {
+          "line": 4,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        53,
+        54
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 19
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        54,
+        55
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 20
+        },
+        "end": {
+          "line": 4,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "value",
+      "range": [
+        55,
+        60
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 21
+        },
+        "end": {
+          "line": 4,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        60,
+        61
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 26
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        61,
+        62
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 27
+        },
+        "end": {
+          "line": 4,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        62,
+        63
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 28
+        },
+        "end": {
+          "line": 4,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        63,
+        64
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 29
+        },
+        "end": {
+          "line": 4,
+          "column": 30
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    65
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind01-scope-output.json
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind01-scope-output.json
@@ -1,0 +1,298 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [
+        {
+          "name": "value",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "value",
+              "range": [
+                13,
+                18
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 9
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "Variable",
+              "name": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              },
+              "node": {
+                "type": "VariableDeclarator",
+                "id": {
+                  "type": "Identifier",
+                  "name": "value",
+                  "range": [
+                    13,
+                    18
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 9
+                    }
+                  }
+                },
+                "init": {
+                  "type": "Literal",
+                  "raw": "''",
+                  "value": "",
+                  "range": [
+                    21,
+                    23
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 14
+                    }
+                  }
+                },
+                "range": [
+                  13,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              },
+              "from": "module",
+              "init": true,
+              "resolved": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  55,
+                  60
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 26
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              13,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 9
+              }
+            }
+          },
+          "from": "module",
+          "init": true,
+          "resolved": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              13,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 9
+              }
+            }
+          }
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              55,
+              60
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 21
+              },
+              "end": {
+                "line": 4,
+                "column": 26
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              13,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 9
+              }
+            }
+          }
+        }
+      ],
+      "childScopes": [],
+      "through": []
+    }
+  ],
+  "through": []
+}

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind02-input.svelte
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind02-input.svelte
@@ -1,0 +1,3 @@
+<script>
+</script>
+<input bind:va.lue/>

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind02-no-undef-result.json
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind02-no-undef-result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ruleId": "no-undef",
+    "code": "va",
+    "line": 3,
+    "column": 13
+  }
+]

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind02-output.json
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind02-output.json
@@ -1,0 +1,586 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteScriptElement",
+      "name": {
+        "type": "SvelteName",
+        "name": "script",
+        "range": [
+          1,
+          7
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [],
+        "selfClosing": false,
+        "range": [
+          0,
+          8
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      },
+      "body": [],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          9,
+          18
+        ],
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 9
+          }
+        }
+      },
+      "range": [
+        0,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "SvelteText",
+      "value": "\n",
+      "range": [
+        18,
+        19
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 9
+        },
+        "end": {
+          "line": 3,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "SvelteElement",
+      "kind": "html",
+      "name": {
+        "type": "SvelteName",
+        "name": "input",
+        "range": [
+          20,
+          25
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 6
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [
+          {
+            "type": "SvelteDirective",
+            "kind": "Binding",
+            "key": {
+              "type": "SvelteDirectiveKey",
+              "name": {
+                "type": "SvelteName",
+                "name": "va.lue",
+                "range": [
+                  31,
+                  37
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 18
+                  }
+                }
+              },
+              "modifiers": [],
+              "range": [
+                26,
+                37
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 7
+                },
+                "end": {
+                  "line": 3,
+                  "column": 18
+                }
+              }
+            },
+            "expression": {
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "type": "Identifier",
+                "name": "va",
+                "range": [
+                  31,
+                  33
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 14
+                  }
+                }
+              },
+              "optional": false,
+              "property": {
+                "type": "Identifier",
+                "name": "lue",
+                "range": [
+                  34,
+                  37
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 18
+                  }
+                }
+              },
+              "range": [
+                31,
+                37
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 12
+                },
+                "end": {
+                  "line": 3,
+                  "column": 18
+                }
+              }
+            },
+            "range": [
+              26,
+              37
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 7
+              },
+              "end": {
+                "line": 3,
+                "column": 18
+              }
+            }
+          }
+        ],
+        "selfClosing": true,
+        "range": [
+          19,
+          39
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 20
+          }
+        }
+      },
+      "children": [],
+      "endTag": null,
+      "range": [
+        19,
+        39
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        1,
+        7
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        7,
+        8
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        9,
+        10
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        10,
+        11
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 1
+        },
+        "end": {
+          "line": 2,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        11,
+        17
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        17,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n",
+      "range": [
+        18,
+        19
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 9
+        },
+        "end": {
+          "line": 3,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        19,
+        20
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "input",
+      "range": [
+        20,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "bind",
+      "range": [
+        26,
+        30
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 7
+        },
+        "end": {
+          "line": 3,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        30,
+        31
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 11
+        },
+        "end": {
+          "line": 3,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "va",
+      "range": [
+        31,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 12
+        },
+        "end": {
+          "line": 3,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ".",
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 14
+        },
+        "end": {
+          "line": 3,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "lue",
+      "range": [
+        34,
+        37
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 15
+        },
+        "end": {
+          "line": 3,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        37,
+        38
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 18
+        },
+        "end": {
+          "line": 3,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        38,
+        39
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    40
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/illegal/dot-in-bind02-scope-output.json
+++ b/tests/fixtures/parser/ast/illegal/dot-in-bind02-scope-output.json
@@ -1,0 +1,106 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "va",
+            "range": [
+              31,
+              33
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 12
+              },
+              "end": {
+                "line": 3,
+                "column": 14
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ],
+      "childScopes": [],
+      "through": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "va",
+            "range": [
+              31,
+              33
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 12
+              },
+              "end": {
+                "line": 3,
+                "column": 14
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    }
+  ],
+  "through": [
+    {
+      "identifier": {
+        "type": "Identifier",
+        "name": "va",
+        "range": [
+          31,
+          33
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 12
+          },
+          "end": {
+            "line": 3,
+            "column": 14
+          }
+        }
+      },
+      "from": "module",
+      "init": null,
+      "resolved": null
+    }
+  ]
+}

--- a/tests/fixtures/parser/ast/illegal/empty-bind01-input.svelte
+++ b/tests/fixtures/parser/ast/illegal/empty-bind01-input.svelte
@@ -1,0 +1,4 @@
+<script>
+let value = ''
+</script>
+<input bind:value=""/>

--- a/tests/fixtures/parser/ast/illegal/empty-bind01-output.json
+++ b/tests/fixtures/parser/ast/illegal/empty-bind01-output.json
@@ -1,0 +1,714 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteScriptElement",
+      "name": {
+        "type": "SvelteName",
+        "name": "script",
+        "range": [
+          1,
+          7
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [],
+        "selfClosing": false,
+        "range": [
+          0,
+          8
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      },
+      "body": [
+        {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              },
+              "init": {
+                "type": "Literal",
+                "raw": "''",
+                "value": "",
+                "range": [
+                  21,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              },
+              "range": [
+                13,
+                23
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 14
+                }
+              }
+            }
+          ],
+          "range": [
+            9,
+            23
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 14
+            }
+          }
+        }
+      ],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          24,
+          33
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 9
+          }
+        }
+      },
+      "range": [
+        0,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "SvelteText",
+      "value": "\n",
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 4,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "SvelteElement",
+      "kind": "html",
+      "name": {
+        "type": "SvelteName",
+        "name": "input",
+        "range": [
+          35,
+          40
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 6
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [
+          {
+            "type": "SvelteDirective",
+            "kind": "Binding",
+            "key": {
+              "type": "SvelteDirectiveKey",
+              "name": {
+                "type": "SvelteName",
+                "name": "value",
+                "range": [
+                  46,
+                  51
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 17
+                  }
+                }
+              },
+              "modifiers": [],
+              "range": [
+                41,
+                51
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 7
+                },
+                "end": {
+                  "line": 4,
+                  "column": 17
+                }
+              }
+            },
+            "expression": {
+              "type": "Identifier",
+              "name": "value",
+              "range": [
+                46,
+                51
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 12
+                },
+                "end": {
+                  "line": 4,
+                  "column": 17
+                }
+              }
+            },
+            "range": [
+              41,
+              54
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 7
+              },
+              "end": {
+                "line": 4,
+                "column": 20
+              }
+            }
+          }
+        ],
+        "selfClosing": true,
+        "range": [
+          34,
+          56
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 22
+          }
+        }
+      },
+      "children": [],
+      "endTag": null,
+      "range": [
+        34,
+        56
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 22
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        1,
+        7
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        7,
+        8
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "let",
+      "range": [
+        9,
+        12
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "value",
+      "range": [
+        13,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 4
+        },
+        "end": {
+          "line": 2,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        19,
+        20
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 10
+        },
+        "end": {
+          "line": 2,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "String",
+      "value": "''",
+      "range": [
+        21,
+        23
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 12
+        },
+        "end": {
+          "line": 2,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        24,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        25,
+        26
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        26,
+        32
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        32,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 8
+        },
+        "end": {
+          "line": 3,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n",
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 4,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        34,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "input",
+      "range": [
+        35,
+        40
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 1
+        },
+        "end": {
+          "line": 4,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "bind",
+      "range": [
+        41,
+        45
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 7
+        },
+        "end": {
+          "line": 4,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        45,
+        46
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 11
+        },
+        "end": {
+          "line": 4,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "value",
+      "range": [
+        46,
+        51
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 12
+        },
+        "end": {
+          "line": 4,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        51,
+        52
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 17
+        },
+        "end": {
+          "line": 4,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        52,
+        53
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 18
+        },
+        "end": {
+          "line": 4,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        53,
+        54
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 19
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        54,
+        55
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 20
+        },
+        "end": {
+          "line": 4,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        55,
+        56
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 21
+        },
+        "end": {
+          "line": 4,
+          "column": 22
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    57
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/illegal/empty-bind01-scope-output.json
+++ b/tests/fixtures/parser/ast/illegal/empty-bind01-scope-output.json
@@ -1,0 +1,298 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [
+        {
+          "name": "value",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "value",
+              "range": [
+                13,
+                18
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 9
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "Variable",
+              "name": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              },
+              "node": {
+                "type": "VariableDeclarator",
+                "id": {
+                  "type": "Identifier",
+                  "name": "value",
+                  "range": [
+                    13,
+                    18
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 9
+                    }
+                  }
+                },
+                "init": {
+                  "type": "Literal",
+                  "raw": "''",
+                  "value": "",
+                  "range": [
+                    21,
+                    23
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 14
+                    }
+                  }
+                },
+                "range": [
+                  13,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              },
+              "from": "module",
+              "init": true,
+              "resolved": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  46,
+                  51
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 17
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "value",
+                "range": [
+                  13,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              13,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 9
+              }
+            }
+          },
+          "from": "module",
+          "init": true,
+          "resolved": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              13,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 9
+              }
+            }
+          }
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              46,
+              51
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 12
+              },
+              "end": {
+                "line": 4,
+                "column": 17
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "value",
+            "range": [
+              13,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 9
+              }
+            }
+          }
+        }
+      ],
+      "childScopes": [],
+      "through": []
+    }
+  ],
+  "through": []
+}

--- a/tests/fixtures/parser/ast/label01-output.json
+++ b/tests/fixtures/parser/ast/label01-output.json
@@ -612,7 +612,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   143,

--- a/tests/fixtures/parser/ast/let-directive01-output.json
+++ b/tests/fixtures/parser/ast/let-directive01-output.json
@@ -195,7 +195,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "foo",
                 "range": [
                   63,
@@ -437,7 +437,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "item",
                     "range": [
                       105,
@@ -509,7 +509,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "item2",
                     "range": [
                       114,
@@ -581,7 +581,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "item3",
                     "range": [
                       124,

--- a/tests/fixtures/parser/ast/let-directive01-scope-output.json
+++ b/tests/fixtures/parser/ast/let-directive01-scope-output.json
@@ -291,7 +291,7 @@
                           "key": {
                             "type": "SvelteDirectiveKey",
                             "name": {
-                              "type": "Identifier",
+                              "type": "SvelteName",
                               "name": "foo",
                               "range": [
                                 63,
@@ -533,7 +533,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item",
                                   "range": [
                                     105,
@@ -605,7 +605,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item2",
                                   "range": [
                                     114,
@@ -677,7 +677,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item3",
                                   "range": [
                                     124,
@@ -1252,7 +1252,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item",
                                   "range": [
                                     105,
@@ -1324,7 +1324,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item2",
                                   "range": [
                                     114,
@@ -1396,7 +1396,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item3",
                                   "range": [
                                     124,
@@ -1796,7 +1796,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item",
                                   "range": [
                                     105,
@@ -1868,7 +1868,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item2",
                                   "range": [
                                     114,
@@ -1940,7 +1940,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item3",
                                   "range": [
                                     124,
@@ -2299,7 +2299,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item",
                                   "range": [
                                     105,
@@ -2371,7 +2371,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item2",
                                   "range": [
                                     114,
@@ -2443,7 +2443,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "item3",
                                   "range": [
                                     124,

--- a/tests/fixtures/parser/ast/store-bindings-output.json
+++ b/tests/fixtures/parser/ast/store-bindings-output.json
@@ -394,7 +394,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   100,
@@ -542,7 +542,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   127,

--- a/tests/fixtures/parser/ast/ts-event01-output.json
+++ b/tests/fixtures/parser/ast/ts-event01-output.json
@@ -253,7 +253,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   79,
@@ -458,7 +458,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   119,

--- a/tests/fixtures/parser/ast/ts-event02-output.json
+++ b/tests/fixtures/parser/ast/ts-event02-output.json
@@ -253,7 +253,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   87,
@@ -458,7 +458,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   127,

--- a/tests/fixtures/parser/ast/tutorial/actions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/actions-output.json
@@ -2286,7 +2286,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "panstart",
                 "range": [
                   831,
@@ -2358,7 +2358,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "panmove",
                 "range": [
                   861,
@@ -2430,7 +2430,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "panend",
                 "range": [
                   889,

--- a/tests/fixtures/parser/ast/tutorial/adding-parameters-to-actions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/adding-parameters-to-actions-output.json
@@ -476,7 +476,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       142,
@@ -951,7 +951,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "longpress",
                 "range": [
                   243,
@@ -1082,7 +1082,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseenter",
                 "range": [
                   282,

--- a/tests/fixtures/parser/ast/tutorial/adding-parameters-to-transitions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/adding-parameters-to-transitions-output.json
@@ -402,7 +402,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       120,

--- a/tests/fixtures/parser/ast/tutorial/animate-output.json
+++ b/tests/fixtures/parser/ast/tutorial/animate-output.json
@@ -4535,7 +4535,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "keydown",
                     "range": [
                       1324,
@@ -5911,7 +5911,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "change",
                                 "range": [
                                   1595,
@@ -6229,7 +6229,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "click",
                                 "range": [
                                   1666,
@@ -7743,7 +7743,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "change",
                                 "range": [
                                   2004,
@@ -8061,7 +8061,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "click",
                                 "range": [
                                   2076,

--- a/tests/fixtures/parser/ast/tutorial/animate-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/animate-scope-output.json
@@ -16804,7 +16804,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "change",
                                       "range": [
                                         1595,
@@ -17122,7 +17122,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "click",
                                       "range": [
                                         1666,
@@ -19691,7 +19691,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "change",
                                       "range": [
                                         2004,
@@ -20009,7 +20009,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "click",
                                       "range": [
                                         2076,

--- a/tests/fixtures/parser/ast/tutorial/await-blocks-output.json
+++ b/tests/fixtures/parser/ast/tutorial/await-blocks-output.json
@@ -935,7 +935,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   326,

--- a/tests/fixtures/parser/ast/tutorial/bind-this-output.json
+++ b/tests/fixtures/parser/ast/tutorial/bind-this-output.json
@@ -3822,7 +3822,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   1073,

--- a/tests/fixtures/parser/ast/tutorial/checkbox-inputs-output.json
+++ b/tests/fixtures/parser/ast/tutorial/checkbox-inputs-output.json
@@ -311,7 +311,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       73,

--- a/tests/fixtures/parser/ast/tutorial/class-shorthand-output.json
+++ b/tests/fixtures/parser/ast/tutorial/class-shorthand-output.json
@@ -420,7 +420,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       120,
@@ -619,7 +619,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "big",
                 "range": [
                   161,

--- a/tests/fixtures/parser/ast/tutorial/classes-output.json
+++ b/tests/fixtures/parser/ast/tutorial/classes-output.json
@@ -305,7 +305,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "selected",
                 "range": [
                   168,
@@ -414,7 +414,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   203,
@@ -656,7 +656,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "selected",
                 "range": [
                   265,
@@ -765,7 +765,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   300,
@@ -1173,7 +1173,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   406,

--- a/tests/fixtures/parser/ast/tutorial/component-bindings01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/component-bindings01-output.json
@@ -982,7 +982,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   265,
@@ -1054,7 +1054,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "submit",
                 "range": [
                   280,

--- a/tests/fixtures/parser/ast/tutorial/component-bindings02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/component-bindings02-output.json
@@ -1061,7 +1061,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       463,
@@ -1283,7 +1283,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       504,
@@ -1505,7 +1505,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       545,
@@ -1727,7 +1727,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       586,
@@ -1949,7 +1949,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       627,
@@ -2171,7 +2171,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       668,
@@ -2393,7 +2393,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       709,
@@ -2615,7 +2615,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       750,
@@ -2837,7 +2837,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       791,
@@ -3152,7 +3152,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       851,
@@ -3335,7 +3335,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       892,
@@ -3650,7 +3650,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       951,

--- a/tests/fixtures/parser/ast/tutorial/component-events01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/component-events01-output.json
@@ -419,7 +419,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "message",
                 "range": [
                   132,

--- a/tests/fixtures/parser/ast/tutorial/component-events02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/component-events02-output.json
@@ -514,7 +514,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   199,

--- a/tests/fixtures/parser/ast/tutorial/contenteditable-bindings-output.json
+++ b/tests/fixtures/parser/ast/tutorial/contenteditable-bindings-output.json
@@ -252,7 +252,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "innerHTML",
                 "range": [
                   92,

--- a/tests/fixtures/parser/ast/tutorial/context-api02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/context-api02-output.json
@@ -2476,7 +2476,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   739,

--- a/tests/fixtures/parser/ast/tutorial/custom-css-transitions01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/custom-css-transitions01-output.json
@@ -1586,7 +1586,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       548,

--- a/tests/fixtures/parser/ast/tutorial/custom-css-transitions02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/custom-css-transitions02-output.json
@@ -1766,7 +1766,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       695,

--- a/tests/fixtures/parser/ast/tutorial/custom-js-transitions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/custom-js-transitions-output.json
@@ -1909,7 +1909,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       550,

--- a/tests/fixtures/parser/ast/tutorial/custom-stores-output.json
+++ b/tests/fixtures/parser/ast/tutorial/custom-stores-output.json
@@ -359,7 +359,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   101,
@@ -579,7 +579,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   147,
@@ -799,7 +799,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   193,

--- a/tests/fixtures/parser/ast/tutorial/debug01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/debug01-output.json
@@ -312,7 +312,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   93,
@@ -497,7 +497,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   129,

--- a/tests/fixtures/parser/ast/tutorial/debug02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/debug02-output.json
@@ -312,7 +312,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   93,
@@ -497,7 +497,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   129,

--- a/tests/fixtures/parser/ast/tutorial/deferred-transitions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/deferred-transitions-output.json
@@ -4444,7 +4444,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "keydown",
                     "range": [
                       1284,
@@ -5765,7 +5765,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "change",
                                 "range": [
                                   1538,
@@ -6083,7 +6083,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "click",
                                 "range": [
                                   1609,
@@ -7466,7 +7466,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "change",
                                 "range": [
                                   1902,
@@ -7784,7 +7784,7 @@
                             "key": {
                               "type": "SvelteDirectiveKey",
                               "name": {
-                                "type": "Identifier",
+                                "type": "SvelteName",
                                 "name": "click",
                                 "range": [
                                   1974,

--- a/tests/fixtures/parser/ast/tutorial/deferred-transitions-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/deferred-transitions-scope-output.json
@@ -16568,7 +16568,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "change",
                                       "range": [
                                         1538,
@@ -16886,7 +16886,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "click",
                                       "range": [
                                         1609,
@@ -19244,7 +19244,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "change",
                                       "range": [
                                         1902,
@@ -19562,7 +19562,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "click",
                                       "range": [
                                         1974,

--- a/tests/fixtures/parser/ast/tutorial/dimensions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/dimensions-output.json
@@ -547,7 +547,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   208,
@@ -695,7 +695,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   234,
@@ -1061,7 +1061,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "clientWidth",
                 "range": [
                   287,
@@ -1133,7 +1133,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "clientHeight",
                 "range": [
                   308,

--- a/tests/fixtures/parser/ast/tutorial/dom-event-forwarding01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/dom-event-forwarding01-output.json
@@ -327,7 +327,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   138,

--- a/tests/fixtures/parser/ast/tutorial/dom-event-forwarding02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/dom-event-forwarding02-output.json
@@ -140,7 +140,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   396,

--- a/tests/fixtures/parser/ast/tutorial/dom-events-output.json
+++ b/tests/fixtures/parser/ast/tutorial/dom-events-output.json
@@ -788,7 +788,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mousemove",
                 "range": [
                   192,

--- a/tests/fixtures/parser/ast/tutorial/each-block-bindings-output.json
+++ b/tests/fixtures/parser/ast/tutorial/each-block-bindings-output.json
@@ -1798,7 +1798,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "done",
                     "range": [
                       458,
@@ -2023,7 +2023,7 @@
                     "key": {
                       "type": "SvelteDirectiveKey",
                       "name": {
-                        "type": "Identifier",
+                        "type": "SvelteName",
                         "name": "checked",
                         "range": [
                           510,
@@ -2264,7 +2264,7 @@
                     "key": {
                       "type": "SvelteDirectiveKey",
                       "name": {
-                        "type": "Identifier",
+                        "type": "SvelteName",
                         "name": "value",
                         "range": [
                           592,
@@ -2663,7 +2663,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   672,
@@ -2846,7 +2846,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   716,

--- a/tests/fixtures/parser/ast/tutorial/each-block-bindings-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/each-block-bindings-scope-output.json
@@ -3219,7 +3219,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "done",
                                   "range": [
                                     458,
@@ -3444,7 +3444,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "checked",
                                       "range": [
                                         510,
@@ -3685,7 +3685,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "value",
                                       "range": [
                                         592,

--- a/tests/fixtures/parser/ast/tutorial/else-blocks-output.json
+++ b/tests/fixtures/parser/ast/tutorial/else-blocks-output.json
@@ -535,7 +535,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       144,
@@ -704,7 +704,7 @@
                   "key": {
                     "type": "SvelteDirectiveKey",
                     "name": {
-                      "type": "Identifier",
+                      "type": "SvelteName",
                       "name": "click",
                       "range": [
                         201,

--- a/tests/fixtures/parser/ast/tutorial/event-forwarding01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/event-forwarding01-output.json
@@ -419,7 +419,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "message",
                 "range": [
                   132,

--- a/tests/fixtures/parser/ast/tutorial/event-forwarding02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/event-forwarding02-output.json
@@ -514,7 +514,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   199,

--- a/tests/fixtures/parser/ast/tutorial/event-forwarding03-output.json
+++ b/tests/fixtures/parser/ast/tutorial/event-forwarding03-output.json
@@ -584,7 +584,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "message",
                 "range": [
                   228,

--- a/tests/fixtures/parser/ast/tutorial/event-forwarding04-output.json
+++ b/tests/fixtures/parser/ast/tutorial/event-forwarding04-output.json
@@ -195,7 +195,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "message",
                 "range": [
                   67,

--- a/tests/fixtures/parser/ast/tutorial/event-modifiers-output.json
+++ b/tests/fixtures/parser/ast/tutorial/event-modifiers-output.json
@@ -254,7 +254,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   86,

--- a/tests/fixtures/parser/ast/tutorial/group-inputs-output.json
+++ b/tests/fixtures/parser/ast/tutorial/group-inputs-output.json
@@ -1346,7 +1346,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "group",
                     "range": [
                       367,
@@ -1735,7 +1735,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "group",
                     "range": [
                       446,
@@ -2124,7 +2124,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "group",
                     "range": [
                       526,
@@ -2664,7 +2664,7 @@
                     "key": {
                       "type": "SvelteDirectiveKey",
                       "name": {
-                        "type": "Identifier",
+                        "type": "SvelteName",
                         "name": "group",
                         "range": [
                           656,

--- a/tests/fixtures/parser/ast/tutorial/group-inputs-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/group-inputs-scope-output.json
@@ -3556,7 +3556,7 @@
                                   "key": {
                                     "type": "SvelteDirectiveKey",
                                     "name": {
-                                      "type": "Identifier",
+                                      "type": "SvelteName",
                                       "name": "group",
                                       "range": [
                                         656,

--- a/tests/fixtures/parser/ast/tutorial/if-blocks-output.json
+++ b/tests/fixtures/parser/ast/tutorial/if-blocks-output.json
@@ -535,7 +535,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       144,
@@ -813,7 +813,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       221,

--- a/tests/fixtures/parser/ast/tutorial/in-and-out-output.json
+++ b/tests/fixtures/parser/ast/tutorial/in-and-out-output.json
@@ -455,7 +455,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       126,

--- a/tests/fixtures/parser/ast/tutorial/inline-handlers-output.json
+++ b/tests/fixtures/parser/ast/tutorial/inline-handlers-output.json
@@ -788,7 +788,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mousemove",
                 "range": [
                   192,

--- a/tests/fixtures/parser/ast/tutorial/keyed-each-blocks-output.json
+++ b/tests/fixtures/parser/ast/tutorial/keyed-each-blocks-output.json
@@ -1149,7 +1149,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   298,

--- a/tests/fixtures/parser/ast/tutorial/local-transitions-output.json
+++ b/tests/fixtures/parser/ast/tutorial/local-transitions-output.json
@@ -849,7 +849,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       309,
@@ -1163,7 +1163,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       385,

--- a/tests/fixtures/parser/ast/tutorial/media-elements-output.json
+++ b/tests/fixtures/parser/ast/tutorial/media-elements-output.json
@@ -4085,7 +4085,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "mousemove",
                     "range": [
                       2287,
@@ -4157,7 +4157,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "mousedown",
                     "range": [
                       2320,
@@ -4229,7 +4229,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "currentTime",
                     "range": [
                       2355,
@@ -4301,7 +4301,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "duration",
                     "range": [
                       2381,
@@ -4373,7 +4373,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "paused",
                     "range": [
                       2397,

--- a/tests/fixtures/parser/ast/tutorial/module-exports01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/module-exports01-output.json
@@ -248,7 +248,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   93,

--- a/tests/fixtures/parser/ast/tutorial/module-exports02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/module-exports02-output.json
@@ -2022,7 +2022,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "playing",
                 "range": [
                   713,
@@ -2557,7 +2557,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "this",
                     "range": [
                       829,
@@ -2629,7 +2629,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "paused",
                     "range": [
                       849,
@@ -2701,7 +2701,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "play",
                     "range": [
                       861,

--- a/tests/fixtures/parser/ast/tutorial/multiple-select-bindings-output.json
+++ b/tests/fixtures/parser/ast/tutorial/multiple-select-bindings-output.json
@@ -1346,7 +1346,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "group",
                     "range": [
                       368,
@@ -1735,7 +1735,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "group",
                     "range": [
                       447,
@@ -2124,7 +2124,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "group",
                     "range": [
                       527,
@@ -2545,7 +2545,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   618,

--- a/tests/fixtures/parser/ast/tutorial/numeric-inputs02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/numeric-inputs02-output.json
@@ -385,7 +385,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       77,
@@ -701,7 +701,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       125,
@@ -1127,7 +1127,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       192,
@@ -1443,7 +1443,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       240,

--- a/tests/fixtures/parser/ast/tutorial/optional-slots03-output.json
+++ b/tests/fixtures/parser/ast/tutorial/optional-slots03-output.json
@@ -492,7 +492,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "has-discussion",
                 "range": [
                   742,

--- a/tests/fixtures/parser/ast/tutorial/reactive-assignments-output.json
+++ b/tests/fixtures/parser/ast/tutorial/reactive-assignments-output.json
@@ -326,7 +326,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   131,

--- a/tests/fixtures/parser/ast/tutorial/reactive-declarations-output.json
+++ b/tests/fixtures/parser/ast/tutorial/reactive-declarations-output.json
@@ -469,7 +469,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   119,

--- a/tests/fixtures/parser/ast/tutorial/reactive-statements-output.json
+++ b/tests/fixtures/parser/ast/tutorial/reactive-statements-output.json
@@ -1199,7 +1199,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   301,

--- a/tests/fixtures/parser/ast/tutorial/select-bindings-output.json
+++ b/tests/fixtures/parser/ast/tutorial/select-bindings-output.json
@@ -1369,7 +1369,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "submit",
                 "range": [
                   505,
@@ -1503,7 +1503,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       557,
@@ -1575,7 +1575,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "change",
                     "range": [
                       577,
@@ -2151,7 +2151,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "value",
                     "range": [
                       736,

--- a/tests/fixtures/parser/ast/tutorial/sharing-code02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/sharing-code02-output.json
@@ -1193,7 +1193,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "playing",
                 "range": [
                   477,
@@ -1728,7 +1728,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "this",
                     "range": [
                       593,
@@ -1800,7 +1800,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "paused",
                     "range": [
                       613,
@@ -1872,7 +1872,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "play",
                     "range": [
                       625,

--- a/tests/fixtures/parser/ast/tutorial/slot-props01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/slot-props01-output.json
@@ -304,7 +304,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "hovering",
                 "range": [
                   231,
@@ -436,7 +436,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "active",
                     "range": [
                       262,

--- a/tests/fixtures/parser/ast/tutorial/slot-props01-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/slot-props01-scope-output.json
@@ -268,7 +268,7 @@
                           "key": {
                             "type": "SvelteDirectiveKey",
                             "name": {
-                              "type": "Identifier",
+                              "type": "SvelteName",
                               "name": "hovering",
                               "range": [
                                 231,
@@ -400,7 +400,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "active",
                                   "range": [
                                     262,

--- a/tests/fixtures/parser/ast/tutorial/slot-props02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/slot-props02-output.json
@@ -438,7 +438,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseenter",
                 "range": [
                   130,
@@ -510,7 +510,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseleave",
                 "range": [
                   152,

--- a/tests/fixtures/parser/ast/tutorial/slot-props03-output.json
+++ b/tests/fixtures/parser/ast/tutorial/slot-props03-output.json
@@ -304,7 +304,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "hovering",
                 "range": [
                   231,
@@ -436,7 +436,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "active",
                     "range": [
                       264,

--- a/tests/fixtures/parser/ast/tutorial/slot-props03-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/slot-props03-scope-output.json
@@ -268,7 +268,7 @@
                           "key": {
                             "type": "SvelteDirectiveKey",
                             "name": {
-                              "type": "Identifier",
+                              "type": "SvelteName",
                               "name": "hovering",
                               "range": [
                                 231,
@@ -400,7 +400,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "active",
                                   "range": [
                                     264,

--- a/tests/fixtures/parser/ast/tutorial/spring-output.json
+++ b/tests/fixtures/parser/ast/tutorial/spring-output.json
@@ -1173,7 +1173,7 @@
                     "key": {
                       "type": "SvelteDirectiveKey",
                       "name": {
-                        "type": "Identifier",
+                        "type": "SvelteName",
                         "name": "value",
                         "range": [
                           371,
@@ -1893,7 +1893,7 @@
                     "key": {
                       "type": "SvelteDirectiveKey",
                       "name": {
-                        "type": "Identifier",
+                        "type": "SvelteName",
                         "name": "value",
                         "range": [
                           510,
@@ -2404,7 +2404,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mousemove",
                 "range": [
                   602,
@@ -2781,7 +2781,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mousedown",
                 "range": [
                   668,
@@ -2951,7 +2951,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseup",
                 "range": [
                   705,

--- a/tests/fixtures/parser/ast/tutorial/svelte-body-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-body-output.json
@@ -569,7 +569,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseenter",
                 "range": [
                   453,
@@ -641,7 +641,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "mouseleave",
                 "range": [
                   487,
@@ -825,7 +825,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "curious",
                 "range": [
                   612,

--- a/tests/fixtures/parser/ast/tutorial/svelte-component-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-component-output.json
@@ -928,7 +928,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   356,

--- a/tests/fixtures/parser/ast/tutorial/svelte-options01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-options01-output.json
@@ -1780,7 +1780,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "click",
                     "range": [
                       537,

--- a/tests/fixtures/parser/ast/tutorial/svelte-options01-scope-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-options01-scope-output.json
@@ -4243,7 +4243,7 @@
                               "key": {
                                 "type": "SvelteDirectiveKey",
                                 "name": {
-                                  "type": "Identifier",
+                                  "type": "SvelteName",
                                   "name": "click",
                                   "range": [
                                     537,

--- a/tests/fixtures/parser/ast/tutorial/svelte-options02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-options02-output.json
@@ -882,7 +882,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   350,
@@ -954,7 +954,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   364,

--- a/tests/fixtures/parser/ast/tutorial/svelte-options03-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-options03-output.json
@@ -844,7 +844,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "this",
                 "range": [
                   343,
@@ -916,7 +916,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   357,

--- a/tests/fixtures/parser/ast/tutorial/svelte-self03-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-self03-output.json
@@ -695,7 +695,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "expanded",
                 "range": [
                   585,
@@ -767,7 +767,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   597,

--- a/tests/fixtures/parser/ast/tutorial/svelte-window-bindings-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-window-bindings-output.json
@@ -423,7 +423,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "scrollY",
                 "range": [
                   94,

--- a/tests/fixtures/parser/ast/tutorial/svelte-window-output.json
+++ b/tests/fixtures/parser/ast/tutorial/svelte-window-output.json
@@ -636,7 +636,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "keydown",
                 "range": [
                   580,

--- a/tests/fixtures/parser/ast/tutorial/text-inputs01-output.json
+++ b/tests/fixtures/parser/ast/tutorial/text-inputs01-output.json
@@ -196,7 +196,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   53,

--- a/tests/fixtures/parser/ast/tutorial/textarea-inputs-output.json
+++ b/tests/fixtures/parser/ast/tutorial/textarea-inputs-output.json
@@ -401,7 +401,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "value",
                 "range": [
                   184,

--- a/tests/fixtures/parser/ast/tutorial/tick-output.json
+++ b/tests/fixtures/parser/ast/tutorial/tick-output.json
@@ -2114,7 +2114,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "keydown",
                 "range": [
                   798,

--- a/tests/fixtures/parser/ast/tutorial/transition-events-output.json
+++ b/tests/fixtures/parser/ast/tutorial/transition-events-output.json
@@ -622,7 +622,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       174,
@@ -1034,7 +1034,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "introstart",
                     "range": [
                       283,
@@ -1165,7 +1165,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "outrostart",
                     "range": [
                       334,
@@ -1296,7 +1296,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "introend",
                     "range": [
                       385,
@@ -1427,7 +1427,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "outroend",
                     "range": [
                       432,

--- a/tests/fixtures/parser/ast/tutorial/transition-output.json
+++ b/tests/fixtures/parser/ast/tutorial/transition-output.json
@@ -402,7 +402,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "checked",
                     "range": [
                       121,

--- a/tests/fixtures/parser/ast/tutorial/tweened-output.json
+++ b/tests/fixtures/parser/ast/tutorial/tweened-output.json
@@ -825,7 +825,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   296,
@@ -1106,7 +1106,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   355,
@@ -1387,7 +1387,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   418,
@@ -1668,7 +1668,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   480,
@@ -1949,7 +1949,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   543,

--- a/tests/fixtures/parser/ast/tutorial/update-output.json
+++ b/tests/fixtures/parser/ast/tutorial/update-output.json
@@ -4143,7 +4143,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "this",
                     "range": [
                       1646,
@@ -4771,7 +4771,7 @@
                 "key": {
                   "type": "SvelteDirectiveKey",
                   "name": {
-                    "type": "Identifier",
+                    "type": "SvelteName",
                     "name": "keydown",
                     "range": [
                       1800,

--- a/tests/fixtures/parser/ast/tutorial/updating-arrays-and-objects-output.json
+++ b/tests/fixtures/parser/ast/tutorial/updating-arrays-and-objects-output.json
@@ -1138,7 +1138,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   230,

--- a/tests/fixtures/parser/ast/tutorial/writable-stores02-output.json
+++ b/tests/fixtures/parser/ast/tutorial/writable-stores02-output.json
@@ -459,7 +459,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   125,

--- a/tests/fixtures/parser/ast/tutorial/writable-stores03-output.json
+++ b/tests/fixtures/parser/ast/tutorial/writable-stores03-output.json
@@ -459,7 +459,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   125,

--- a/tests/fixtures/parser/ast/tutorial/writable-stores04-output.json
+++ b/tests/fixtures/parser/ast/tutorial/writable-stores04-output.json
@@ -382,7 +382,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   109,

--- a/tests/fixtures/parser/ast/unused-write-only-store-output.json
+++ b/tests/fixtures/parser/ast/unused-write-only-store-output.json
@@ -629,7 +629,7 @@
             "key": {
               "type": "SvelteDirectiveKey",
               "name": {
-                "type": "Identifier",
+                "type": "SvelteName",
                 "name": "click",
                 "range": [
                   204,


### PR DESCRIPTION
- Change the key of some directives such as `bind:` from `Identifier` to `SvelteName`. Because it may contain dots.