### PR TITLE
Chore: Use GitHub Pages Custom GitHub Actions Workflows

### DIFF
--- a/.github/workflows/GHPages.yml
+++ b/.github/workflows/GHPages.yml
@@ -5,11 +5,26 @@ on:
   push:
     branches: [main]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
-  deploy-docs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Install And Build
         run: |+
@@ -19,9 +34,12 @@ jobs:
           yarn install
           yarn pre-build
           yarn build
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./explorer-v2/build
-          force_orphan: true
+          path: ./explorer-v2/build
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR modifies the workflow to deploy to GitHub Pages without using the gh-pages branch.

See https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/

Note: We need to change the settings before merging it.