### PR TITLE
fix: resolve to module scope for top level statements

### DIFF
--- a/.changeset/dull-bananas-trade.md
+++ b/.changeset/dull-bananas-trade.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+fix: resolve to module scope for top level statements

--- a/src/scope/index.ts
+++ b/src/scope/index.ts
@@ -3,7 +3,6 @@ import type * as ESTree from "estree";
 import type { TSESTree } from "@typescript-eslint/types";
 import { traverseNodes } from "../traverse";
 import { addElementsToSortedArray, addElementToSortedArray } from "../utils";
-import type { SvelteHTMLNode } from "../ast";
 
 /** Remove all scope, variable, and reference */
 export function removeAllScopeAndVariableAndReference(
@@ -59,9 +58,9 @@ export function removeAllScopeAndVariableAndReference(
  */
 export function getScopeFromNode(
   scopeManager: ScopeManager,
-  currentNode: ESTree.Node | SvelteHTMLNode
+  currentNode: ESTree.Node
 ): Scope {
-  let node: ESTree.Node | SvelteHTMLNode | null = currentNode;
+  let node: ESTree.Node | null = currentNode;
   for (; node; node = (node as any).parent || null) {
     const scope = scopeManager.acquire(node, false);
     if (scope) {
@@ -79,10 +78,7 @@ export function getScopeFromNode(
     }
   }
   const global = scopeManager.globalScope;
-
-  return currentNode.type === "Program" || currentNode.type === "SvelteScriptElement" ?
-         global :
-         getProgramScope(scopeManager);
+  return global;
 }
 /**
  * Gets the scope for the Program node

--- a/src/scope/index.ts
+++ b/src/scope/index.ts
@@ -3,6 +3,7 @@ import type * as ESTree from "estree";
 import type { TSESTree } from "@typescript-eslint/types";
 import { traverseNodes } from "../traverse";
 import { addElementsToSortedArray, addElementToSortedArray } from "../utils";
+import type { SvelteHTMLNode } from "../ast";
 
 /** Remove all scope, variable, and reference */
 export function removeAllScopeAndVariableAndReference(
@@ -58,9 +59,9 @@ export function removeAllScopeAndVariableAndReference(
  */
 export function getScopeFromNode(
   scopeManager: ScopeManager,
-  currentNode: ESTree.Node
+  currentNode: ESTree.Node | SvelteHTMLNode
 ): Scope {
-  let node: ESTree.Node | null = currentNode;
+  let node: ESTree.Node | SvelteHTMLNode | null = currentNode;
   for (; node; node = (node as any).parent || null) {
     const scope = scopeManager.acquire(node, false);
     if (scope) {
@@ -78,7 +79,10 @@ export function getScopeFromNode(
     }
   }
   const global = scopeManager.globalScope;
-  return global;
+
+  return currentNode.type === "Program" || currentNode.type === "SvelteScriptElement" ?
+         global :
+         getProgramScope(scopeManager);
 }
 /**
  * Gets the scope for the Program node

--- a/tests/src/scope/scope.ts
+++ b/tests/src/scope/scope.ts
@@ -1,61 +1,69 @@
 import assert from "assert";
-import { parseForESLint } from "../../../src";
-import { getScopeFromNode } from "../../../src/scope";
+import * as svelte from "../../../src";
+import { FlatESLint } from 'eslint/use-at-your-own-risk';
 
-describe('getScopeFromNode', () => {
-	it('returns the global scope for the root node', () => {
-		const { ast, scopeManager } = parseForESLint('');
+async function generateScopeTestCase(code, selector, type) {
+	const eslint = new FlatESLint({
+		overrideConfigFile: true,
+		overrideConfig: {
+			languageOptions: {
+				parser: svelte,
+			},
+			plugins: {
+				local: {
+					rules: {
+						rule: generateScopeRule(selector, type),
+					}
+				}
+			},
+			rules: {
+				'local/rule': 'error',
+			}
+		}
+	});
+	await eslint.lintText(code);
+}
 
-		assert.strictEqual(getScopeFromNode(scopeManager, ast), scopeManager.globalScope);
+function generateScopeRule(selector, type) {
+	return {
+		create(context) {
+			return {
+				[selector]() {
+					const scope = context.getScope();
+	
+					assert.strictEqual(scope.type, type);
+				}	
+			};
+		}
+	}
+}
+
+describe('context.getScope', () => {
+	it('returns the global scope for the root node', async () => {
+		await generateScopeTestCase('', 'Program', 'global');
 	});
 
-	it('returns the global scope for the script element', () => {
-		const { ast, scopeManager } = parseForESLint('<script></script>');
-		const script = ast.body[0];
-
-		assert.strictEqual(getScopeFromNode(scopeManager, script), scopeManager.globalScope);
+	it('returns the global scope for the script element', async () => {
+		await generateScopeTestCase('<script></script>', 'SvelteScriptElement', 'global');
 	});
 
-	it('returns the module scope for nodes for top level nodes of script', () => {
-		const { ast, scopeManager } = parseForESLint('<script>import mod from "mod";</script>');
-		const importStatement = ast.body[0].body[0];
-
-		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0]);
+	it.only('returns the module scope for nodes for top level nodes of script', async () => {
+		await generateScopeTestCase('<script>import mod from "mod";</script>', 'ImportDeclaration', 'module');
 	});
 
-	it('returns the module scope for nested nodes without their own scope', () => {
-		const { ast, scopeManager } = parseForESLint('<script>a || b</script>');
-		const importStatement = ast.body[0].body[0].expression.right;
-
-		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0]);
+	it('returns the module scope for nested nodes without their own scope', async () => {
+		await generateScopeTestCase('<script>a || b</script>', 'LogicalExpression', 'module');
 	});
 
-	it('returns the module scope for nested nodes for non-modules', () => {
-		const { ast, scopeManager } = parseForESLint('<script>a || b</script>', { sourceType: 'script' });
-		const importStatement = ast.body[0].body[0].expression.right;
-
-		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0]);
+	it('returns the the child scope of top level nodes with their own scope', async () => {
+		await generateScopeTestCase('<script>function fn() {}</script>', 'FunctionDeclaration', 'function');
 	});
 
-	it('returns the the child scope of top level nodes with their own scope', () => {
-		const { ast, scopeManager } = parseForESLint('<script>function fn() {}</script>');
-		const fnNode = ast.body[0].body[0];
-
-		assert.strictEqual(getScopeFromNode(scopeManager, fnNode), scopeManager.globalScope.childScopes[0].childScopes[0]);
+	it('returns the own scope for nested nodes', async () => {
+		await generateScopeTestCase('<script>a || (() => {})</script>', 'ArrowFunctionExpression', 'function');
 	});
 
-	it('returns the own scope for nested nodes', () => {
-		const { ast, scopeManager } = parseForESLint('<script>a || (() => {})</script>');
-		const importStatement = ast.body[0].body[0].expression.right;
-
-		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0].childScopes[0]);
-	});
-
-	it('returns the the nearest child scope for statements inside non-global scopes', () => {
-		const { ast, scopeManager } = parseForESLint('<script>function fn() { nested; }</script>');
-		const fnNode = ast.body[0].body[0];
-		const nestedStatement = fnNode.body.body[0];
-
-		assert.strictEqual(getScopeFromNode(scopeManager, nestedStatement), scopeManager.globalScope.childScopes[0].childScopes[0]);
+	it('returns the the nearest child scope for statements inside non-global scopes', async () => {
+		await generateScopeTestCase('<script>function fn() { nested; }</script>', 'ExpressionStatement', 'function');
 	});
 });

--- a/tests/src/scope/scope.ts
+++ b/tests/src/scope/scope.ts
@@ -1,0 +1,61 @@
+import assert from "assert";
+import { parseForESLint } from "../../../src";
+import { getScopeFromNode } from "../../../src/scope";
+
+describe('getScopeFromNode', () => {
+	it('returns the global scope for the root node', () => {
+		const { ast, scopeManager } = parseForESLint('');
+
+		assert.strictEqual(getScopeFromNode(scopeManager, ast), scopeManager.globalScope);
+	});
+
+	it('returns the global scope for the script element', () => {
+		const { ast, scopeManager } = parseForESLint('<script></script>');
+		const script = ast.body[0];
+
+		assert.strictEqual(getScopeFromNode(scopeManager, script), scopeManager.globalScope);
+	});
+
+	it('returns the module scope for nodes for top level nodes of script', () => {
+		const { ast, scopeManager } = parseForESLint('<script>import mod from "mod";</script>');
+		const importStatement = ast.body[0].body[0];
+
+		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0]);
+	});
+
+	it('returns the module scope for nested nodes without their own scope', () => {
+		const { ast, scopeManager } = parseForESLint('<script>a || b</script>');
+		const importStatement = ast.body[0].body[0].expression.right;
+
+		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0]);
+	});
+
+	it('returns the module scope for nested nodes for non-modules', () => {
+		const { ast, scopeManager } = parseForESLint('<script>a || b</script>', { sourceType: 'script' });
+		const importStatement = ast.body[0].body[0].expression.right;
+
+		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0]);
+	});
+
+	it('returns the the child scope of top level nodes with their own scope', () => {
+		const { ast, scopeManager } = parseForESLint('<script>function fn() {}</script>');
+		const fnNode = ast.body[0].body[0];
+
+		assert.strictEqual(getScopeFromNode(scopeManager, fnNode), scopeManager.globalScope.childScopes[0].childScopes[0]);
+	});
+
+	it('returns the own scope for nested nodes', () => {
+		const { ast, scopeManager } = parseForESLint('<script>a || (() => {})</script>');
+		const importStatement = ast.body[0].body[0].expression.right;
+
+		assert.strictEqual(getScopeFromNode(scopeManager, importStatement), scopeManager.globalScope.childScopes[0].childScopes[0]);
+	});
+
+	it('returns the the nearest child scope for statements inside non-global scopes', () => {
+		const { ast, scopeManager } = parseForESLint('<script>function fn() { nested; }</script>');
+		const fnNode = ast.body[0].body[0];
+		const nestedStatement = fnNode.body.body[0];
+
+		assert.strictEqual(getScopeFromNode(scopeManager, nestedStatement), scopeManager.globalScope.childScopes[0].childScopes[0]);
+	});
+});


### PR DESCRIPTION
Fixes #280.
`scopeManager.acquire(node)` returns null in these cases.
The fix is to only return the global scope for the root `Program` node (consistent with other eslint parsers) and `SvelteScriptElement` (as I would expect it as it is for me also a root node)
Some notes:
- There seems to always be a module scope as in the parseForESLint method the sourceType is always overwritten to "module"
- Are there other scenarios where scopeManager.acquire returns null?
