### PR TITLE
fix: correctly use `compilerOptions.runes` if set as a function

### DIFF
--- a/.changeset/thin-suits-remain.md
+++ b/.changeset/thin-suits-remain.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: use the Svelte config `compilerOptions.runes` function value if set

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.enable": true
+  "eslint.enable": true,
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "prettier-plugin-pkg": "^0.21.2",
     "prettier-plugin-svelte": "^3.4.0",
     "rimraf": "^6.0.1",
-    "svelte": "^5.53.7",
+    "svelte": "^5.55.5",
     "svelte2tsx": "^0.7.45",
     "tsx": "^4.20.5",
     "typescript": "~5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 7.1.0
       semver:
         specifier: ^7.7.2
-        version: 7.7.3
+        version: 7.7.4
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.6.0
@@ -578,21 +578,11 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
@@ -609,10 +599,6 @@ packages:
   '@eslint/core@0.16.0':
     resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/core@1.0.1':
-    resolution: {integrity: sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.1.0':
     resolution: {integrity: sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==}
@@ -666,14 +652,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -881,11 +859,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -1654,10 +1627,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -1671,10 +1640,6 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -1782,10 +1747,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -1978,11 +1939,6 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -2080,10 +2036,6 @@ packages:
   svelte@5.55.5:
     resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
-
-  synckit@0.11.11:
-    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
 
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
@@ -2281,7 +2233,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -2290,7 +2242,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -2331,7 +2283,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -2356,7 +2308,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@changesets/get-github-info@0.8.0':
     dependencies:
@@ -2598,17 +2550,10 @@ snapshots:
       eslint: 9.38.0
       ignore: 7.0.5
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0)':
-    dependencies:
-      eslint: 9.38.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.38.0)':
     dependencies:
       eslint: 9.38.0
       eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint-community/regexpp@4.12.2': {}
 
@@ -2625,10 +2570,6 @@ snapshots:
       '@eslint/core': 0.16.0
 
   '@eslint/core@0.16.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
-  '@eslint/core@1.0.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -2686,12 +2627,6 @@ snapshots:
       iconv-lite: 0.7.0
     optionalDependencies:
       '@types/node': 24.9.1
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2935,15 +2870,9 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       eslint-visitor-keys: 5.0.0
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-
-  acorn@8.15.0: {}
 
   acorn@8.16.0: {}
 
@@ -3247,7 +3176,7 @@ snapshots:
       html-entities: 2.6.0
       object-deep-merge: 2.0.0
       parse-imports-exports: 0.2.4
-      semver: 7.7.3
+      semver: 7.7.4
       spdx-expression-parse: 4.0.0
       to-valid-identifier: 1.0.0
     transitivePeerDependencies:
@@ -3255,15 +3184,15 @@ snapshots:
 
   eslint-plugin-json-schema-validator@6.0.0(eslint@9.38.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0)
       ajv: 8.17.1
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.38.0
       eslint-json-compat-utils: 0.2.1(eslint@9.38.0)(jsonc-eslint-parser@2.4.1)
       json-schema-migrate-x: 2.1.0
       jsonc-eslint-parser: 2.4.1
-      minimatch: 10.0.3
-      synckit: 0.11.11
+      minimatch: 10.2.4
+      synckit: 0.11.12
       toml-eslint-parser: 1.0.3
       tunnel-agent: 0.6.0
       yaml-eslint-parser: 2.0.0
@@ -3273,8 +3202,8 @@ snapshots:
 
   eslint-plugin-jsonc@3.0.0(eslint@9.38.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
-      '@eslint/core': 1.0.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0)
+      '@eslint/core': 1.1.0
       '@eslint/plugin-kit': 0.6.0
       '@ota-meshi/ast-token-store': 0.2.3
       diff-sequences: 29.6.3
@@ -3288,7 +3217,7 @@ snapshots:
 
   eslint-plugin-n@17.23.1(eslint@9.38.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0)
       enhanced-resolve: 5.18.3
       eslint: 9.38.0
       eslint-plugin-es-x: 7.8.0(eslint@9.38.0)
@@ -3296,7 +3225,7 @@ snapshots:
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
-      semver: 7.7.3
+      semver: 7.7.4
       ts-declaration-location: 1.0.7(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
@@ -3316,15 +3245,15 @@ snapshots:
       eslint: 9.38.0
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
-      synckit: 0.11.11
+      synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
       eslint-config-prettier: 10.1.8(eslint@9.38.0)
 
   eslint-plugin-regexp@3.0.0(eslint@9.38.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0)
+      '@eslint-community/regexpp': 4.12.2
       comment-parser: 1.4.1
       eslint: 9.38.0
       jsdoc-type-pratt-parser: 7.0.0
@@ -3334,7 +3263,7 @@ snapshots:
 
   eslint-plugin-svelte@3.12.4(eslint@9.38.0)(svelte@5.55.5(@typescript-eslint/types@8.56.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0)
       '@jridgewell/sourcemap-codec': 1.5.5
       eslint: 9.38.0
       esutils: 2.0.3
@@ -3343,7 +3272,7 @@ snapshots:
       postcss: 8.5.6
       postcss-load-config: 3.1.4(postcss@8.5.6)
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
-      semver: 7.7.3
+      semver: 7.7.4
       svelte-eslint-parser: 1.3.3(svelte@5.55.5(@typescript-eslint/types@8.56.0))
     optionalDependencies:
       svelte: 5.55.5(@typescript-eslint/types@8.56.0)
@@ -3352,7 +3281,7 @@ snapshots:
 
   eslint-plugin-yml@3.0.0(eslint@9.38.0):
     dependencies:
-      '@eslint/core': 1.0.1
+      '@eslint/core': 1.1.0
       '@eslint/plugin-kit': 0.5.1
       debug: 4.4.3(supports-color@8.1.1)
       diff-sequences: 29.6.3
@@ -3417,8 +3346,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   espree@11.0.0:
@@ -3547,7 +3476,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -3556,9 +3485,9 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
       minimatch: 10.2.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
+      path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
@@ -3697,7 +3626,7 @@ snapshots:
       acorn: 8.16.0
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
-      semver: 7.7.3
+      semver: 7.7.4
 
   jsonc-eslint-parser@3.1.0:
     dependencies:
@@ -3764,10 +3693,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  minimatch@10.0.3:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
-
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -3781,8 +3706,6 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
-
-  minipass@7.1.2: {}
 
   minipass@7.1.3: {}
 
@@ -3896,12 +3819,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.2.2
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -4055,8 +3973,6 @@ snapshots:
 
   scule@1.3.0: {}
 
-  semver@7.7.3: {}
-
   semver@7.7.4: {}
 
   serialize-javascript@6.0.2:
@@ -4163,10 +4079,6 @@ snapshots:
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
-
-  synckit@0.11.11:
-    dependencies:
-      '@pkgr/core': 0.2.9
 
   synckit@0.11.12:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 3.0.0(eslint@9.38.0)
       eslint-plugin-svelte:
         specifier: ^3.12.2
-        version: 3.12.4(eslint@9.38.0)(svelte@5.53.7)
+        version: 3.12.4(eslint@9.38.0)(svelte@5.55.5(@typescript-eslint/types@8.56.0))
       eslint-plugin-yml:
         specifier: ^3.0.0
         version: 3.0.0(eslint@9.38.0)
@@ -158,16 +158,16 @@ importers:
         version: 0.21.2(prettier@3.6.2)
       prettier-plugin-svelte:
         specifier: ^3.4.0
-        version: 3.4.0(prettier@3.6.2)(svelte@5.53.7)
+        version: 3.4.0(prettier@3.6.2)(svelte@5.55.5(@typescript-eslint/types@8.56.0))
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       svelte:
-        specifier: ^5.53.7
-        version: 5.53.7
+        specifier: ^5.55.5
+        version: 5.55.5(@typescript-eslint/types@8.56.0)
       svelte2tsx:
         specifier: ^0.7.45
-        version: 0.7.45(svelte@5.53.7)(typescript@5.9.3)
+        version: 0.7.45(svelte@5.55.5(@typescript-eslint/types@8.56.0))(typescript@5.9.3)
       tsx:
         specifier: ^4.20.5
         version: 4.20.6
@@ -179,7 +179,7 @@ importers:
         version: 8.56.0(eslint@9.38.0)(typescript@5.9.3)
       typescript-eslint-parser-for-extra-files:
         specifier: ^0.9.0
-        version: 0.9.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0)(typescript@5.9.3))(svelte2tsx@0.7.45(svelte@5.53.7)(typescript@5.9.3))(typescript@5.9.3)
+        version: 0.9.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0)(typescript@5.9.3))(svelte2tsx@0.7.45(svelte@5.55.5(@typescript-eslint/types@8.56.0))(typescript@5.9.3))(typescript@5.9.3)
 
 packages:
 
@@ -1079,8 +1079,8 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
-  devalue@5.6.3:
-    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+  devalue@5.8.0:
+    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -1292,8 +1292,13 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.2.3:
-    resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
+  esrap@2.2.6:
+    resolution: {integrity: sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -2072,8 +2077,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.53.7:
-    resolution: {integrity: sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==}
+  svelte@5.55.5:
+    resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
 
   synckit@0.11.11:
@@ -3100,7 +3105,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  devalue@5.6.3: {}
+  devalue@5.8.0: {}
 
   diff-sequences@29.6.3: {}
 
@@ -3327,7 +3332,7 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-svelte@3.12.4(eslint@9.38.0)(svelte@5.53.7):
+  eslint-plugin-svelte@3.12.4(eslint@9.38.0)(svelte@5.55.5(@typescript-eslint/types@8.56.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0)
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3339,9 +3344,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.6)
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.3
-      svelte-eslint-parser: 1.3.3(svelte@5.53.7)
+      svelte-eslint-parser: 1.3.3(svelte@5.55.5(@typescript-eslint/types@8.56.0))
     optionalDependencies:
-      svelte: 5.53.7
+      svelte: 5.55.5(@typescript-eslint/types@8.56.0)
     transitivePeerDependencies:
       - ts-node
 
@@ -3434,9 +3439,11 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.3:
+  esrap@2.2.6(@typescript-eslint/types@8.56.0):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.56.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -3949,10 +3956,10 @@ snapshots:
     dependencies:
       prettier: 3.6.2
 
-  prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.53.7):
+  prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.55.5(@typescript-eslint/types@8.56.0)):
     dependencies:
       prettier: 3.6.2
-      svelte: 5.53.7
+      svelte: 5.55.5(@typescript-eslint/types@8.56.0)
 
   prettier@2.8.8: {}
 
@@ -4118,7 +4125,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-eslint-parser@1.3.3(svelte@5.53.7):
+  svelte-eslint-parser@1.3.3(svelte@5.55.5(@typescript-eslint/types@8.56.0)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -4127,16 +4134,16 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.6)
       postcss-selector-parser: 7.1.0
     optionalDependencies:
-      svelte: 5.53.7
+      svelte: 5.55.5(@typescript-eslint/types@8.56.0)
 
-  svelte2tsx@0.7.45(svelte@5.53.7)(typescript@5.9.3):
+  svelte2tsx@0.7.45(svelte@5.55.5(@typescript-eslint/types@8.56.0))(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.53.7
+      svelte: 5.55.5(@typescript-eslint/types@8.56.0)
       typescript: 5.9.3
 
-  svelte@5.53.7:
+  svelte@5.55.5(@typescript-eslint/types@8.56.0):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4147,13 +4154,15 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.3
+      devalue: 5.8.0
       esm-env: 1.2.2
-      esrap: 2.2.3
+      esrap: 2.2.6(@typescript-eslint/types@8.56.0)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.19
       zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   synckit@0.11.11:
     dependencies:
@@ -4217,12 +4226,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint-parser-for-extra-files@0.9.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0)(typescript@5.9.3))(svelte2tsx@0.7.45(svelte@5.53.7)(typescript@5.9.3))(typescript@5.9.3):
+  typescript-eslint-parser-for-extra-files@0.9.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0)(typescript@5.9.3))(svelte2tsx@0.7.45(svelte@5.55.5(@typescript-eslint/types@8.56.0))(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.38.0)(typescript@5.9.3)
       tinyglobby: 0.2.15
     optionalDependencies:
-      svelte2tsx: 0.7.45(svelte@5.53.7)(typescript@5.9.3)
+      svelte2tsx: 0.7.45(svelte@5.55.5(@typescript-eslint/types@8.56.0))(typescript@5.9.3)
       typescript: 5.9.3
 
   typescript-eslint@8.56.0(eslint@9.38.0)(typescript@5.9.3):

--- a/src/parser/svelte-parse-context.ts
+++ b/src/parser/svelte-parse-context.ts
@@ -73,7 +73,11 @@ function isRunesAsParseContext(
     return parserOptions.svelteFeatures?.runes;
   }
   if (svelteConfig?.compilerOptions?.runes != null) {
-    return svelteConfig?.compilerOptions?.runes;
+    return typeof svelteConfig.compilerOptions?.runes === "function"
+      ? svelteConfig.compilerOptions.runes({
+          filename: parserOptions.filePath ?? "",
+        })
+      : svelteConfig.compilerOptions?.runes;
   }
 
   // `<svelte:options>`.

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding01-input.svelte
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding01-input.svelte
@@ -1,1 +1,1 @@
-<input bind:value={(x, y)}/>
+<input bind:value={x, y}/>

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding01-no-undef-result.json
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding01-no-undef-result.json
@@ -3,12 +3,12 @@
     "ruleId": "no-undef",
     "code": "x",
     "line": 1,
-    "column": 21
+    "column": 20
   },
   {
     "ruleId": "no-undef",
     "code": "y",
     "line": 1,
-    "column": 24
+    "column": 23
   }
 ]

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding01-output.json
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding01-output.json
@@ -65,23 +65,23 @@
               }
             },
             "expression": {
-              "type": "SequenceExpression",
+              "type": "SvelteFunctionBindingsExpression",
               "expressions": [
                 {
                   "type": "Identifier",
                   "name": "x",
                   "range": [
-                    20,
-                    21
+                    19,
+                    20
                   ],
                   "loc": {
                     "start": {
                       "line": 1,
-                      "column": 20
+                      "column": 19
                     },
                     "end": {
                       "line": 1,
-                      "column": 21
+                      "column": 20
                     }
                   }
                 },
@@ -89,40 +89,40 @@
                   "type": "Identifier",
                   "name": "y",
                   "range": [
-                    23,
-                    24
+                    22,
+                    23
                   ],
                   "loc": {
                     "start": {
                       "line": 1,
-                      "column": 23
+                      "column": 22
                     },
                     "end": {
                       "line": 1,
-                      "column": 24
+                      "column": 23
                     }
                   }
                 }
               ],
               "range": [
-                20,
-                24
+                19,
+                23
               ],
               "loc": {
                 "start": {
                   "line": 1,
-                  "column": 20
+                  "column": 19
                 },
                 "end": {
                   "line": 1,
-                  "column": 24
+                  "column": 23
                 }
               }
             },
             "shorthand": false,
             "range": [
               7,
-              26
+              24
             ],
             "loc": {
               "start": {
@@ -131,7 +131,7 @@
               },
               "end": {
                 "line": 1,
-                "column": 26
+                "column": 24
               }
             }
           }
@@ -139,7 +139,7 @@
         "selfClosing": true,
         "range": [
           0,
-          28
+          26
         ],
         "loc": {
           "start": {
@@ -148,7 +148,7 @@
           },
           "end": {
             "line": 1,
-            "column": 28
+            "column": 26
           }
         }
       },
@@ -156,7 +156,7 @@
       "endTag": null,
       "range": [
         0,
-        28
+        26
       ],
       "loc": {
         "start": {
@@ -165,7 +165,7 @@
         },
         "end": {
           "line": 1,
-          "column": 28
+          "column": 26
         }
       }
     }
@@ -300,8 +300,8 @@
       }
     },
     {
-      "type": "Punctuator",
-      "value": "(",
+      "type": "Identifier",
+      "value": "x",
       "range": [
         19,
         20
@@ -318,8 +318,8 @@
       }
     },
     {
-      "type": "Identifier",
-      "value": "x",
+      "type": "Punctuator",
+      "value": ",",
       "range": [
         20,
         21
@@ -336,26 +336,26 @@
       }
     },
     {
-      "type": "Punctuator",
-      "value": ",",
+      "type": "Identifier",
+      "value": "y",
       "range": [
-        21,
-        22
+        22,
+        23
       ],
       "loc": {
         "start": {
           "line": 1,
-          "column": 21
+          "column": 22
         },
         "end": {
           "line": 1,
-          "column": 22
+          "column": 23
         }
       }
     },
     {
-      "type": "Identifier",
-      "value": "y",
+      "type": "Punctuator",
+      "value": "}",
       "range": [
         23,
         24
@@ -373,7 +373,7 @@
     },
     {
       "type": "Punctuator",
-      "value": ")",
+      "value": "/",
       "range": [
         24,
         25
@@ -391,7 +391,7 @@
     },
     {
       "type": "Punctuator",
-      "value": "}",
+      "value": ">",
       "range": [
         25,
         26
@@ -406,47 +406,11 @@
           "column": 26
         }
       }
-    },
-    {
-      "type": "Punctuator",
-      "value": "/",
-      "range": [
-        26,
-        27
-      ],
-      "loc": {
-        "start": {
-          "line": 1,
-          "column": 26
-        },
-        "end": {
-          "line": 1,
-          "column": 27
-        }
-      }
-    },
-    {
-      "type": "Punctuator",
-      "value": ">",
-      "range": [
-        27,
-        28
-      ],
-      "loc": {
-        "start": {
-          "line": 1,
-          "column": 27
-        },
-        "end": {
-          "line": 1,
-          "column": 28
-        }
-      }
     }
   ],
   "range": [
     0,
-    29
+    27
   ],
   "loc": {
     "start": {

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding01-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding01-scope-output.json
@@ -73,17 +73,17 @@
             "type": "Identifier",
             "name": "x",
             "range": [
-              20,
-              21
+              19,
+              20
             ],
             "loc": {
               "start": {
                 "line": 1,
-                "column": 20
+                "column": 19
               },
               "end": {
                 "line": 1,
-                "column": 21
+                "column": 20
               }
             }
           },
@@ -96,17 +96,17 @@
             "type": "Identifier",
             "name": "y",
             "range": [
-              23,
-              24
+              22,
+              23
             ],
             "loc": {
               "start": {
                 "line": 1,
-                "column": 23
+                "column": 22
               },
               "end": {
                 "line": 1,
-                "column": 24
+                "column": 23
               }
             }
           },
@@ -122,17 +122,17 @@
             "type": "Identifier",
             "name": "x",
             "range": [
-              20,
-              21
+              19,
+              20
             ],
             "loc": {
               "start": {
                 "line": 1,
-                "column": 20
+                "column": 19
               },
               "end": {
                 "line": 1,
-                "column": 21
+                "column": 20
               }
             }
           },
@@ -145,17 +145,17 @@
             "type": "Identifier",
             "name": "y",
             "range": [
-              23,
-              24
+              22,
+              23
             ],
             "loc": {
               "start": {
                 "line": 1,
-                "column": 23
+                "column": 22
               },
               "end": {
                 "line": 1,
-                "column": 24
+                "column": 23
               }
             }
           },
@@ -172,17 +172,17 @@
         "type": "Identifier",
         "name": "x",
         "range": [
-          20,
-          21
+          19,
+          20
         ],
         "loc": {
           "start": {
             "line": 1,
-            "column": 20
+            "column": 19
           },
           "end": {
             "line": 1,
-            "column": 21
+            "column": 20
           }
         }
       },
@@ -195,17 +195,17 @@
         "type": "Identifier",
         "name": "y",
         "range": [
-          23,
-          24
+          22,
+          23
         ],
         "loc": {
           "start": {
             "line": 1,
-            "column": 23
+            "column": 22
           },
           "end": {
             "line": 1,
-            "column": 24
+            "column": 23
           }
         }
       },

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding02-input.svelte
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding02-input.svelte
@@ -1,5 +1,5 @@
 <input bind:value={
     /* Foo */
-    (x,
-    y)
+    x,
+    y
     }/>

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding02-no-undef-result.json
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding02-no-undef-result.json
@@ -3,7 +3,7 @@
     "ruleId": "no-undef",
     "code": "x",
     "line": 3,
-    "column": 6
+    "column": 5
   },
   {
     "ruleId": "no-undef",

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding02-output.json
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding02-output.json
@@ -65,23 +65,23 @@
               }
             },
             "expression": {
-              "type": "SequenceExpression",
+              "type": "SvelteFunctionBindingsExpression",
               "expressions": [
                 {
                   "type": "Identifier",
                   "name": "x",
                   "range": [
-                    39,
-                    40
+                    38,
+                    39
                   ],
                   "loc": {
                     "start": {
                       "line": 3,
-                      "column": 5
+                      "column": 4
                     },
                     "end": {
                       "line": 3,
-                      "column": 6
+                      "column": 5
                     }
                   }
                 },
@@ -89,8 +89,8 @@
                   "type": "Identifier",
                   "name": "y",
                   "range": [
-                    46,
-                    47
+                    45,
+                    46
                   ],
                   "loc": {
                     "start": {
@@ -105,13 +105,13 @@
                 }
               ],
               "range": [
-                39,
-                47
+                38,
+                46
               ],
               "loc": {
                 "start": {
                   "line": 3,
-                  "column": 5
+                  "column": 4
                 },
                 "end": {
                   "line": 4,
@@ -122,7 +122,7 @@
             "shorthand": false,
             "range": [
               7,
-              54
+              52
             ],
             "loc": {
               "start": {
@@ -139,7 +139,7 @@
         "selfClosing": true,
         "range": [
           0,
-          56
+          54
         ],
         "loc": {
           "start": {
@@ -156,7 +156,7 @@
       "endTag": null,
       "range": [
         0,
-        56
+        54
       ],
       "loc": {
         "start": {
@@ -319,8 +319,8 @@
       }
     },
     {
-      "type": "Punctuator",
-      "value": "(",
+      "type": "Identifier",
+      "value": "x",
       "range": [
         38,
         39
@@ -337,8 +337,8 @@
       }
     },
     {
-      "type": "Identifier",
-      "value": "x",
+      "type": "Punctuator",
+      "value": ",",
       "range": [
         39,
         40
@@ -355,29 +355,11 @@
       }
     },
     {
-      "type": "Punctuator",
-      "value": ",",
-      "range": [
-        40,
-        41
-      ],
-      "loc": {
-        "start": {
-          "line": 3,
-          "column": 6
-        },
-        "end": {
-          "line": 3,
-          "column": 7
-        }
-      }
-    },
-    {
       "type": "Identifier",
       "value": "y",
       "range": [
-        46,
-        47
+        45,
+        46
       ],
       "loc": {
         "start": {
@@ -392,28 +374,10 @@
     },
     {
       "type": "Punctuator",
-      "value": ")",
-      "range": [
-        47,
-        48
-      ],
-      "loc": {
-        "start": {
-          "line": 4,
-          "column": 5
-        },
-        "end": {
-          "line": 4,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": "Punctuator",
       "value": "}",
       "range": [
-        53,
-        54
+        51,
+        52
       ],
       "loc": {
         "start": {
@@ -430,8 +394,8 @@
       "type": "Punctuator",
       "value": "/",
       "range": [
-        54,
-        55
+        52,
+        53
       ],
       "loc": {
         "start": {
@@ -448,8 +412,8 @@
       "type": "Punctuator",
       "value": ">",
       "range": [
-        55,
-        56
+        53,
+        54
       ],
       "loc": {
         "start": {
@@ -465,7 +429,7 @@
   ],
   "range": [
     0,
-    57
+    55
   ],
   "loc": {
     "start": {

--- a/tests/fixtures/parser/ast/svelte5/non-function-binding02-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/non-function-binding02-scope-output.json
@@ -73,17 +73,17 @@
             "type": "Identifier",
             "name": "x",
             "range": [
-              39,
-              40
+              38,
+              39
             ],
             "loc": {
               "start": {
                 "line": 3,
-                "column": 5
+                "column": 4
               },
               "end": {
                 "line": 3,
-                "column": 6
+                "column": 5
               }
             }
           },
@@ -96,8 +96,8 @@
             "type": "Identifier",
             "name": "y",
             "range": [
-              46,
-              47
+              45,
+              46
             ],
             "loc": {
               "start": {
@@ -122,17 +122,17 @@
             "type": "Identifier",
             "name": "x",
             "range": [
-              39,
-              40
+              38,
+              39
             ],
             "loc": {
               "start": {
                 "line": 3,
-                "column": 5
+                "column": 4
               },
               "end": {
                 "line": 3,
-                "column": 6
+                "column": 5
               }
             }
           },
@@ -145,8 +145,8 @@
             "type": "Identifier",
             "name": "y",
             "range": [
-              46,
-              47
+              45,
+              46
             ],
             "loc": {
               "start": {
@@ -172,17 +172,17 @@
         "type": "Identifier",
         "name": "x",
         "range": [
-          39,
-          40
+          38,
+          39
         ],
         "loc": {
           "start": {
             "line": 3,
-            "column": 5
+            "column": 4
           },
           "end": {
             "line": 3,
-            "column": 6
+            "column": 5
           }
         }
       },
@@ -195,8 +195,8 @@
         "type": "Identifier",
         "name": "y",
         "range": [
-          46,
-          47
+          45,
+          46
         ],
         "loc": {
           "start": {


### PR DESCRIPTION
fixes the error in https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/25303653052/job/74175124307#step:7:260 and for users who are using the function form of the setting