### PR TITLE
ci: declare contents:read on Node CI workflow

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `.github/workflows/NodeCI.yml` to `permissions: contents: read` at the workflow level. The lint, build, and matrix-test jobs only clone the repo, set up pnpm and Node, run `pnpm install --frozen-lockfile`, then lint/build/test. No GitHub API calls beyond the checkout, no actions/cache directive, nothing here needs write access.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the practical reason for the cap. A tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the blast radius matched whatever scope the token was issued with. Setting a per-workflow minimum bounds the runtime authority of every action that runs inside it - including the pinned actions already in use here - independent of whatever the org or repo default is set to today, and survives any future default-widening change. OpenSSF Scorecard's Token-Permissions check only credits the explicit per-workflow declaration. The actions in this file are already SHA-pinned which is the bigger win; this small block closes the remaining gap.

Diff validated locally with `yaml.safe_load`.
