### PR TITLE
ci: declare contents:read on pkg.pr.new workflow

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
     tags: ["!**"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'sveltejs/svelte-eslint-parser'


### PR DESCRIPTION
Sets `permissions: contents: read` at the top of `.github/workflows/pkg.pr.new.yml`. The publish step explicitly passes `--comment=off` to `pkg-pr-new`, so the workflow does not post PR comments and does not need `pull-requests: write`. The `actions/github-script` step only reads/writes the local `output.json` file (no GitHub API calls), and `actions/upload-artifact` operates against the run's own artifact scope. `pkg-pr-new` itself uses `GITHUB_TOKEN` for publisher identity verification, which is a read-only operation.

This is supply-chain hardening rooted in CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) where a tampered third-party action exfiltrated `GITHUB_TOKEN` via the workflow logs. The leaked token retained whatever scope was issued, so a per-workflow cap bounds the runtime blast radius regardless of repo or org default. Drift protection plus OpenSSF Scorecard Token-Permissions credit come along with it.

YAML validated locally with `yaml.safe_load`.
