### PR TITLE
[WIP] In-memory ts.sys.readFile hook for Svelte (no disk cache)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,3 +36,10 @@ export { syncVirtualCode, type SyncOptions } from "./cli/sync.js";
 // that don't opt in pay nothing. See `tsconfig-interceptor.ts` for rationale.
 import { installTsconfigInterceptor } from "./virtual-code/tsconfig-interceptor.js";
 installTsconfigInterceptor();
+
+// Install the `ts.sys.readFile` hook that serves Svelte files as virtual TS
+// directly to TypeScript's projectService — no `.svelte-eslint-parser/`
+// directory, no generated tsconfig, no CLI sync. Opt-in via
+// `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`.
+import { installTsSysHook } from "./ts-sys-hook.js";
+installTsSysHook();

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -60,6 +60,7 @@ import { resolveSvelteConfigFromOption } from "../svelte-config/index.js";
 import { getESLintScope } from "./eslint-scope.js";
 import { getVirtualCodeCacheManager } from "../virtual-code/index.js";
 import { initializeVirtualCodeCache } from "./virtual-code-initializer.js";
+import { rememberParserOptions } from "../ts-sys-hook.js";
 
 export {
   StyleContext,
@@ -118,6 +119,11 @@ type ParseResult = {
 export function parseForESLint(code: string, options?: any): ParseResult {
   const svelteConfig = resolveSvelteConfigFromOption(options);
   const parserOptions = normalizeParserOptions(options);
+
+  // The ts.sys.readFile hook needs the same parser/svelte settings ESLint
+  // hands us in order to translate `.svelte` files on demand. Refresh them on
+  // every parse; the last set wins for subsequent in-process TS reads.
+  rememberParserOptions(parserOptions);
 
   // Initialize virtual code cache for TypeScript type-aware linting
   // Only enabled when svelteFeatures.experimentalGenerateVirtualCodeCache is true

--- a/src/parser/virtual-code-initializer.ts
+++ b/src/parser/virtual-code-initializer.ts
@@ -39,7 +39,7 @@ export function initializeVirtualCodeCache(
  * Generate virtual TypeScript code for a Svelte file.
  * Returns null if the file cannot be processed or is not TypeScript.
  */
-function generateVirtualCodeForFile(
+export function generateVirtualCodeForFile(
   filePath: string,
   content: string,
   parserOptions: NormalizedParserOptions,

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -1,0 +1,125 @@
+import fs from "fs";
+import path from "path";
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import type { NormalizedParserOptions } from "./parser/parser-options.js";
+import { generateVirtualCodeForFile } from "./parser/virtual-code-initializer.js";
+
+/**
+ * In-memory bridge that lets TypeScript's projectService type-check Svelte
+ * files without any on-disk artifacts.
+ *
+ * When installed, we patch `ts.sys.readFile`. For paths ending in `.svelte`,
+ * we translate the source to virtual TypeScript on demand (using the same
+ * `analyzeTypeScriptInSvelte` pipeline ESLint already exercises) and return
+ * that string. Every other read passes through untouched, so ESLint's own
+ * file reads still see the original Svelte source. There is no
+ * `.svelte-eslint-parser/` directory, no generated tsconfig, no CLI sync
+ * step, and projectService discovers only one program — the user's.
+ *
+ * Activation: `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`.
+ */
+
+const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
+
+interface CacheEntry {
+  mtimeMs: number;
+  virtualCode: string;
+}
+
+const translationCache = new Map<string, CacheEntry>();
+let activeParserOptions: NormalizedParserOptions | null = null;
+let installed = false;
+
+/**
+ * Record the most recent parser options ESLint passed in. Translation needs
+ * the user's parser + svelte settings (e.g. `parser`, `svelteFeatures`,
+ * `extraFileExtensions`), and the parse entry point is the only place those
+ * options are guaranteed to flow through.
+ */
+export function rememberParserOptions(options: NormalizedParserOptions): void {
+  activeParserOptions = options;
+}
+
+function translateSvelteFile(filePath: string): string | null {
+  if (!activeParserOptions) return null;
+
+  let mtimeMs: number;
+  try {
+    mtimeMs = fs.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+  const cached = translationCache.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.virtualCode;
+
+  let svelteSource: string;
+  try {
+    svelteSource = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const result = generateVirtualCodeForFile(
+    filePath,
+    svelteSource,
+    activeParserOptions,
+  );
+  if (!result) return null;
+
+  translationCache.set(filePath, { mtimeMs, virtualCode: result.code });
+  return result.code;
+}
+
+/**
+ * Load the TypeScript module that typescript-eslint will use. We resolve from
+ * the user's project so we end up patching the same instance projectService
+ * later imports — otherwise our `ts.sys` patch would target a different
+ * `require.cache` entry.
+ */
+function loadTypeScript(): typeof import("typescript") | null {
+  const here =
+    typeof __dirname !== "undefined"
+      ? __dirname
+      : path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(process.cwd(), "package.json"),
+    path.join(here, "package.json"),
+  ];
+  for (const from of candidates) {
+    try {
+      return createRequire(from)("typescript") as typeof import("typescript");
+    } catch {
+      // try next candidate
+    }
+  }
+  try {
+    return createRequire(import.meta.url)(
+      "typescript",
+    ) as typeof import("typescript");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install the `ts.sys.readFile` patch. Idempotent. No-op unless the env flag
+ * is set or TypeScript cannot be resolved from the project.
+ */
+export function installTsSysHook(): void {
+  if (installed) return;
+  if (process.env[ENV_FLAG] !== "1") return;
+
+  const ts = loadTypeScript();
+  if (!ts?.sys?.readFile) return;
+  installed = true;
+
+  const originalReadFile = ts.sys.readFile.bind(ts.sys);
+  ts.sys.readFile = (filePath: string, encoding?: string) => {
+    if (typeof filePath === "string" && filePath.endsWith(".svelte")) {
+      const virtual = translateSvelteFile(filePath);
+      if (virtual !== null) return virtual;
+    }
+    return originalReadFile(filePath, encoding);
+  };
+}


### PR DESCRIPTION
**Status: WIP / exploration.** Pairs with #(parent issue/PR for `feat/virtual-file`); targets that branch so the diff stays small.

## Why

The disk-based virtual code cache works (eslint-svelte-ts-perf goes from ~50s → ~5s) but ships a lot of moving parts:

- a `.svelte-eslint-parser/` directory in every project
- a generated `tsconfig.svelte-virtual.json`
- a `svelte-eslint-parser-sync` CLI step
- in-process `filePath` swaps inside the parser
- a fragile interaction with `projectService: true` that can spawn a second program and run a large internal app out of memory

This branch replaces all of that with a single in-process hook.

## What

`installTsSysHook()` patches `ts.sys.readFile` when `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. For paths ending in `.svelte`, it translates the source to virtual TS in memory (reusing the existing `generateVirtualCodeForFile` pipeline) and returns the string. Everything else passes through.

- ESLint still reads the original `.svelte` for the parser (we hook `ts.sys`, not `fs`).
- The user's existing `tsconfig.json` covers `.svelte` via `extraFileExtensions: ['.svelte']` — projectService discovers exactly one program.
- Results are cached by `(path, mtime)`; an edit invalidates automatically.
- `parseForESLint` primes the hook with each set of normalized parser options so translation has the user's parser/svelte settings.

No `.svelte-eslint-parser/` directory, no tsconfig generation, no CLI sync, no `filePath` rewrite.

## Measurements

All `eslint --no-cache --concurrency auto`.

| Project | Config | Wall | Notes |
| --- | --- | --- | --- |
| eslint-svelte-ts-perf (1001 components) | baseline | 51 s | |
| | ts.sys hook (warm 1) | **6.5 s** | 2002 errors match baseline |
| | ts.sys hook (warm 2) | **6.2 s** | |
| internal app (388 .svelte + 530 .ts, broad `tsconfig.include`) | baseline | 475 s | |
| | disk-cache + projectService:true | >20 min | hangs near OOM |
| | disk-cache + tsconfig interceptor | 525 s | |
| | disk-cache + legacy `project:` mode | 386 s | |
| | **ts.sys hook (this PR)** | **250 s** | first measured run, moderate machine load |

## Open questions before un-WIP

- Where to import `typescript` from when multiple instances exist in `node_modules`. Current implementation resolves from `process.cwd()` → parser directory → import.meta.url. Probably fine for projectService since it does the same dance, but worth sanity-checking on monorepos with peer-resolved TS.
- Source-position mapping for diagnostics that TS reports from inside the virtual file. Lint rules go through the parser's existing position map; raw TS diagnostics surfaced by rules like `sonarjs/deprecation` may still need a `getSourceFile` shim.
- Whether to keep the disk-cache code in tree, gate it behind another flag, or strip it once this approach is judged the winner.
- Tests: nothing added yet. Want to write a fixture that asserts `ts.sys.readFile` returns virtual content for `.svelte` and the original bytes otherwise.

## How to try locally

```sh
SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 \
  eslint --no-cache --concurrency auto .
```

That's the only change — no parser config tweaks, no extra CLI invocation.