### PR TITLE
feat: experimental ts.sys.readFile hook for type-aware Svelte lint

### DIFF
--- a/.changeset/ts-sys-hook.md
+++ b/.changeset/ts-sys-hook.md
@@ -3,5 +3,5 @@
 ---
 
 Add an experimental `ts.sys.readFile` hook that speeds up type-aware lint
-of `.svelte` files. Opt in with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. See
+of `.svelte` files. Opt in with `SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`. See
 the Experimental section in the README for details.

--- a/.changeset/ts-sys-hook.md
+++ b/.changeset/ts-sys-hook.md
@@ -2,7 +2,6 @@
 "svelte-eslint-parser": minor
 ---
 
-Add an experimental `ts.sys.readFile` hook for type-aware Svelte lint.
-Activate with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`; TypeScript reads each
-`.svelte` file as virtual TypeScript on demand, no cache directory or CLI
-sync required. See the Experimental section in the README.
+Add an experimental `ts.sys.readFile` hook that speeds up type-aware lint
+of `.svelte` files. Opt in with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. See
+the Experimental section in the README for details.

--- a/.changeset/ts-sys-hook.md
+++ b/.changeset/ts-sys-hook.md
@@ -1,0 +1,22 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Add an in-memory `ts.sys.readFile` hook that lets `@typescript-eslint/parser`'s
+projectService type-check Svelte files without on-disk artifacts. Activate
+with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. When enabled, the parser
+translates each `.svelte` file to virtual TypeScript on demand (memoized by
+`(path, mtime)`) and returns it from `ts.sys.readFile`. ESLint's own reads
+still see the original Svelte source, the user's `tsconfig.json` is the only
+program projectService discovers, and there is no cache directory to manage.
+
+Measured impact (eslint-svelte-ts-perf, 1001 components):
+
+- baseline (`projectService: true`, no hook): ~50s
+- with hook, warm runs: ~5–6s
+
+Known limitation: lint rules that surface raw TypeScript diagnostics via
+`program.getSemanticDiagnostics()` and friends will report positions in the
+virtual TS, not the original Svelte. Type-aware rules that go through
+`services.getTypeAtLocation(node)` use the parser's AST positions and are
+unaffected.

--- a/.changeset/ts-sys-hook.md
+++ b/.changeset/ts-sys-hook.md
@@ -2,21 +2,7 @@
 "svelte-eslint-parser": minor
 ---
 
-Add an in-memory `ts.sys.readFile` hook that lets `@typescript-eslint/parser`'s
-projectService type-check Svelte files without on-disk artifacts. Activate
-with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. When enabled, the parser
-translates each `.svelte` file to virtual TypeScript on demand (memoized by
-`(path, mtime)`) and returns it from `ts.sys.readFile`. ESLint's own reads
-still see the original Svelte source, the user's `tsconfig.json` is the only
-program projectService discovers, and there is no cache directory to manage.
-
-Measured impact (eslint-svelte-ts-perf, 1001 components):
-
-- baseline (`projectService: true`, no hook): ~50s
-- with hook, warm runs: ~5–6s
-
-Known limitation: lint rules that surface raw TypeScript diagnostics via
-`program.getSemanticDiagnostics()` and friends will report positions in the
-virtual TS, not the original Svelte. Type-aware rules that go through
-`services.getTypeAtLocation(node)` use the parser's AST positions and are
-unaffected.
+Add an experimental `ts.sys.readFile` hook for type-aware Svelte lint.
+Activate with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`; TypeScript reads each
+`.svelte` file as virtual TypeScript on demand, no cache directory or CLI
+sync required. See the Experimental section in the README.

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -101,6 +101,21 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Test
         run: pnpm run test
+  test-with-ts-sys-hook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Use Node.js latest
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: latest
+      - name: Install Packages
+        run: pnpm install --frozen-lockfile
+      - name: Test with ts.sys hook enabled
+        env:
+          SVELTE_ESLINT_PARSER_TS_SYS_HOOK: "1"
+        run: pnpm run test
   update-fixtures:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -114,7 +114,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Test with ts.sys hook enabled
         env:
-          SVELTE_ESLINT_PARSER_TS_SYS_HOOK: "1"
+          SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK: "1"
         run: pnpm run test
   update-fixtures:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -249,6 +249,44 @@ export default [
 
 ---
 
+## Experimental
+
+### `ts.sys.readFile` hook for type-aware Svelte lint
+
+> ⚠️ **Experimental.** Opt-in only, may change or be removed in any release.
+> Please report regressions before relying on it for CI.
+
+Type-aware lint of `.svelte` files with `@typescript-eslint/parser`'s
+`projectService: true` is normally expensive: `projectService` discovers a
+`tsconfig.json` per file, which makes every `.svelte` walk through
+TypeScript's project resolution every time it is read.
+
+Setting the environment variable below installs an in-process hook on
+`ts.sys.readFile`. When TypeScript reads a `.svelte` file, the parser
+translates it to virtual TypeScript on demand and returns the shim. ESLint's
+own reads of `.svelte` go through `fs` and are unaffected, and TypeScript
+sees exactly one program — the user's existing `tsconfig.json` (which must
+list `.svelte` via `parserOptions.extraFileExtensions`).
+
+```sh
+SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 \
+  eslint --no-cache --concurrency auto .
+```
+
+No cache directory, no generated tsconfig, no CLI sync step. Translations
+are memoized by `(path, mtime)`, so an edit invalidates automatically.
+
+#### Known limitation
+
+Lint rules that surface raw TypeScript diagnostics via
+`program.getSemanticDiagnostics()` or `program.getSuggestionDiagnostics()`
+will report positions inside the virtual TypeScript shim, not the original
+Svelte source. Type-aware rules that go through
+`services.getTypeAtLocation(node)` use the parser's AST positions and are
+unaffected.
+
+---
+
 ## Editor Integrations
 
 ### Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Speeds up type-aware lint of `.svelte` files. Your ESLint config must
 already list `.svelte` via `parserOptions.extraFileExtensions`.
 
 ```sh
-SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 \
+SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1 \
   eslint --no-cache --concurrency auto .
 ```
 

--- a/README.md
+++ b/README.md
@@ -276,14 +276,23 @@ SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 \
 No cache directory, no generated tsconfig, no CLI sync step. Translations
 are memoized by `(path, mtime)`, so an edit invalidates automatically.
 
-#### Known limitation
+#### Notes on positions
 
-Lint rules that surface raw TypeScript diagnostics via
-`program.getSemanticDiagnostics()` or `program.getSuggestionDiagnostics()`
-will report positions inside the virtual TypeScript shim, not the original
-Svelte source. Type-aware rules that go through
-`services.getTypeAtLocation(node)` use the parser's AST positions and are
-unaffected.
+Type-aware lint of `.svelte` files always works against the parser's
+virtual TypeScript shim: `services.getTypeAtLocation(node)` is fine
+because the node positions are restored to the original Svelte source by
+the parser's `restoreContext`, but a rule that reads raw diagnostics out
+of TypeScript (`program.getSemanticDiagnostics(sourceFile)` and friends)
+sees positions that index into the shim, not the Svelte source.
+
+This is a pre-existing characteristic of type-aware Svelte lint —
+TypeScript only ever sees the shim, regardless of whether the hook is
+on. The hook does not change positions for the file being parsed.
+
+What the hook does change is cross-file resolution: a sibling
+`import './Other.svelte'` resolves to actual virtual TypeScript instead
+of an opaque `declare module '*.svelte'`, so type-aware rules report
+better information through the affected nodes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ export default [
 
 ### `ts.sys.readFile` hook for type-aware Svelte lint
 
-> ⚠️ **Experimental.** Opt-in only; behaviour may change or be removed.
+> ⚠️ **Experimental.** Opt-in only; behavior may change or be removed.
 
 Speeds up type-aware lint of `.svelte` files. Your ESLint config must
 already list `.svelte` via `parserOptions.extraFileExtensions`.

--- a/README.md
+++ b/README.md
@@ -253,46 +253,20 @@ export default [
 
 ### `ts.sys.readFile` hook for type-aware Svelte lint
 
-> ⚠️ **Experimental.** Opt-in only, may change or be removed in any release.
-> Please report regressions before relying on it for CI.
+> ⚠️ **Experimental.** Opt-in only; behaviour may change or be removed.
 
-Type-aware lint of `.svelte` files with `@typescript-eslint/parser`'s
-`projectService: true` is normally expensive: `projectService` discovers a
-`tsconfig.json` per file, which makes every `.svelte` walk through
-TypeScript's project resolution every time it is read.
-
-Setting the environment variable below installs an in-process hook on
-`ts.sys.readFile`. When TypeScript reads a `.svelte` file, the parser
-translates it to virtual TypeScript on demand and returns the shim. ESLint's
-own reads of `.svelte` go through `fs` and are unaffected, and TypeScript
-sees exactly one program — the user's existing `tsconfig.json` (which must
-list `.svelte` via `parserOptions.extraFileExtensions`).
+Speeds up type-aware lint of `.svelte` files. Your ESLint config must
+already list `.svelte` via `parserOptions.extraFileExtensions`.
 
 ```sh
 SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 \
   eslint --no-cache --concurrency auto .
 ```
 
-No cache directory, no generated tsconfig, no CLI sync step. Translations
-are memoized by `(path, mtime)`, so an edit invalidates automatically.
-
-#### Notes on positions
-
-Type-aware lint of `.svelte` files always works against the parser's
-virtual TypeScript shim: `services.getTypeAtLocation(node)` is fine
-because the node positions are restored to the original Svelte source by
-the parser's `restoreContext`, but a rule that reads raw diagnostics out
-of TypeScript (`program.getSemanticDiagnostics(sourceFile)` and friends)
-sees positions that index into the shim, not the Svelte source.
-
-This is a pre-existing characteristic of type-aware Svelte lint —
-TypeScript only ever sees the shim, regardless of whether the hook is
-on. The hook does not change positions for the file being parsed.
-
-What the hook does change is cross-file resolution: a sibling
-`import './Other.svelte'` resolves to actual virtual TypeScript instead
-of an opaque `declare module '*.svelte'`, so type-aware rules report
-better information through the affected nodes.
+Caveat: rules that read raw TypeScript diagnostics
+(`program.getSemanticDiagnostics()` and friends) report positions inside
+the parser's virtual shim — a pre-existing property of type-aware Svelte
+lint, not specific to the hook.
 
 ---
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,3 +27,10 @@ export const VisitorKeys = KEYS;
 
 // tools
 export { traverseNodes };
+
+// Install the `ts.sys.readFile` hook that lets TypeScript type-check Svelte
+// files through `@typescript-eslint/parser`'s projectService without any
+// on-disk artifacts. Gated by `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`, so
+// projects that don't opt in pay nothing.
+import { installTsSysHook } from "./ts-sys-hook.js";
+installTsSysHook();

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,9 +28,6 @@ export const VisitorKeys = KEYS;
 // tools
 export { traverseNodes };
 
-// Install the `ts.sys.readFile` hook that lets TypeScript type-check Svelte
-// files through `@typescript-eslint/parser`'s projectService without any
-// on-disk artifacts. Gated by `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`, so
-// projects that don't opt in pay nothing.
+// Opt-in `ts.sys.readFile` hook. See `ts-sys-hook.ts`.
 import { installTsSysHook } from "./ts-sys-hook.js";
 installTsSysHook();

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -58,6 +58,7 @@ import {
 import type { SvelteConfig } from "../svelte-config/index.js";
 import { resolveSvelteConfigFromOption } from "../svelte-config/index.js";
 import { getESLintScope } from "./eslint-scope.js";
+import { rememberParserOptions } from "../ts-sys-hook.js";
 
 export {
   StyleContext,
@@ -116,6 +117,10 @@ type ParseResult = {
 export function parseForESLint(code: string, options?: any): ParseResult {
   const svelteConfig = resolveSvelteConfigFromOption(options);
   const parserOptions = normalizeParserOptions(options);
+
+  // Keep the `ts.sys` hook in sync with the parser/svelte config ESLint is
+  // currently using. The latest set wins for any in-process TS read.
+  rememberParserOptions(parserOptions);
 
   if (
     parserOptions.filePath &&

--- a/src/parser/svelte-to-virtual-ts.ts
+++ b/src/parser/svelte-to-virtual-ts.ts
@@ -1,0 +1,62 @@
+import { Context } from "../context/index.js";
+import { resolveSvelteConfigFromOption } from "../svelte-config/index.js";
+import type { NormalizedParserOptions } from "./parser-options.js";
+import { parseTemplate } from "./template.js";
+import { analyzeTypeScriptInSvelte } from "./typescript/analyze/index.js";
+import { resolveSvelteParseContextForSvelte } from "./svelte-parse-context.js";
+
+/**
+ * Translate a Svelte component to the virtual TypeScript shim that the rest
+ * of `parseTypeScriptInSvelte` would hand to `@typescript-eslint/parser`.
+ *
+ * Pulled out so the `ts.sys.readFile` hook can produce the same shim on
+ * demand, without going through ESLint's parse entry point.
+ *
+ * Returns `null` if:
+ *   - parsing fails for any reason, or
+ *   - the file has no `<script lang="ts">` block (nothing to type-check).
+ */
+export function svelteToVirtualTypeScript(
+  filePath: string,
+  content: string,
+  parserOptions: NormalizedParserOptions,
+): string | null {
+  try {
+    // Strip `project` / `projectService` from the inner options. We are
+    // already running inside `@typescript-eslint/parser`'s call stack via the
+    // `ts.sys` hook; if we left them in, the inner analyzer would try to
+    // initialise its own program and either deadlock or recurse forever.
+    const inner: NormalizedParserOptions = {
+      ...parserOptions,
+      filePath,
+      project: null,
+      projectService: undefined,
+      EXPERIMENTAL_useProjectService: undefined,
+    };
+
+    const ctx = new Context(content, inner);
+    if (!ctx.isTypeScript()) return null;
+
+    const template = parseTemplate(ctx.sourceCode.template, ctx, inner);
+    const svelteConfig = resolveSvelteConfigFromOption({
+      ...parserOptions,
+      filePath,
+    });
+    const svelteParseContext = resolveSvelteParseContextForSvelte(
+      svelteConfig,
+      inner,
+      template.svelteAst,
+    );
+
+    const scripts = ctx.sourceCode.scripts;
+    const tsCtx = analyzeTypeScriptInSvelte(
+      scripts.getCurrentVirtualCodeInfo(),
+      scripts.attrs,
+      inner,
+      { slots: ctx.slots, svelteParseContext },
+    );
+    return tsCtx.script;
+  } catch {
+    return null;
+  }
+}

--- a/src/parser/svelte-to-virtual-ts.ts
+++ b/src/parser/svelte-to-virtual-ts.ts
@@ -6,15 +6,8 @@ import { analyzeTypeScriptInSvelte } from "./typescript/analyze/index.js";
 import { resolveSvelteParseContextForSvelte } from "./svelte-parse-context.js";
 
 /**
- * Translate a Svelte component to the virtual TypeScript shim that the rest
- * of `parseTypeScriptInSvelte` would hand to `@typescript-eslint/parser`.
- *
- * Pulled out so the `ts.sys.readFile` hook can produce the same shim on
- * demand, without going through ESLint's parse entry point.
- *
- * Returns `null` if:
- *   - parsing fails for any reason, or
- *   - the file has no `<script lang="ts">` block (nothing to type-check).
+ * Translate a Svelte component to the virtual TypeScript shim. Returns
+ * `null` if the file has no `<script lang="ts">` or parsing fails.
  */
 export function svelteToVirtualTypeScript(
   filePath: string,
@@ -22,10 +15,9 @@ export function svelteToVirtualTypeScript(
   parserOptions: NormalizedParserOptions,
 ): string | null {
   try {
-    // Strip `project` / `projectService` from the inner options. We are
-    // already running inside `@typescript-eslint/parser`'s call stack via the
-    // `ts.sys` hook; if we left them in, the inner analyzer would try to
-    // initialise its own program and either deadlock or recurse forever.
+    // Drop `project` / `projectService`: we're already inside
+    // `@typescript-eslint/parser`'s stack via the `ts.sys` hook, and a nested
+    // analyzer trying to spin up its own program would deadlock or recurse.
     const inner: NormalizedParserOptions = {
       ...parserOptions,
       filePath,

--- a/src/parser/typescript/index.ts
+++ b/src/parser/typescript/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./analyze/index.js";
 import { setParent } from "./set-parent.js";
 import type { TSESParseForESLintResult } from "./types.js";
+import { primeTranslationCache } from "../../ts-sys-hook.js";
 
 /**
  * Parse for TypeScript in <script>
@@ -20,6 +21,14 @@ export function parseTypeScriptInSvelte(
   context: AnalyzeTypeScriptContext,
 ): ESLintExtendedProgram {
   const tsCtx = analyzeTypeScriptInSvelte(code, attrs, parserOptions, context);
+
+  // Share the freshly-produced shim with the `ts.sys` hook. If the hook is
+  // off this is a no-op; if it is on it spares projectService from running
+  // `analyzeTypeScriptInSvelte` again when it reaches for the same file
+  // through `ts.sys.readFile`.
+  if (parserOptions.filePath) {
+    primeTranslationCache(parserOptions.filePath, tsCtx.script);
+  }
 
   const result = parseScriptInSvelte(tsCtx.script, attrs, parserOptions);
 

--- a/src/parser/typescript/index.ts
+++ b/src/parser/typescript/index.ts
@@ -22,10 +22,7 @@ export function parseTypeScriptInSvelte(
 ): ESLintExtendedProgram {
   const tsCtx = analyzeTypeScriptInSvelte(code, attrs, parserOptions, context);
 
-  // Share the freshly-produced shim with the `ts.sys` hook. If the hook is
-  // off this is a no-op; if it is on it spares projectService from running
-  // `analyzeTypeScriptInSvelte` again when it reaches for the same file
-  // through `ts.sys.readFile`.
+  // Share the shim with the ts.sys hook so projectService reads hit a cache.
   if (parserOptions.filePath) {
     primeTranslationCache(parserOptions.filePath, tsCtx.script);
   }

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -43,13 +43,7 @@ export function rememberParserOptions(options: NormalizedParserOptions): void {
   patchAllLoadedTypeScripts();
 }
 
-/**
- * Seed the translation cache from the parser's own pipeline. The parser
- * already produces virtual TS for the file it is currently parsing;
- * stashing it here lets `ts.sys.readFile` serve the same string without
- * re-running `analyzeTypeScriptInSvelte` if `projectService` later reaches
- * for the file on disk.
- */
+/** Seed the cache so a later `ts.sys.readFile` skips re-translating. */
 export function primeTranslationCache(
   filePath: string,
   virtualCode: string,

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -12,6 +12,7 @@ import { loadNewestModule } from "./utils/cjs-module.js";
  */
 
 const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
+const DEBUG_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK_DEBUG";
 
 interface TranslationEntry {
   mtimeMs: number;
@@ -26,13 +27,93 @@ interface TsLike {
 
 const translations = new Map<string, TranslationEntry>();
 const patchedSysObjects = new WeakSet();
+const patchedTsPaths = new Set<string>();
 let activeParserOptions: NormalizedParserOptions | null = null;
 let installed = false;
 let needsParseTimeRescan = false;
+let firstParserOptionsLogged = false;
+
+// Debug counters. Cheap when DEBUG flag is off; useful when on.
+const counters = {
+  readFileCalls: 0,
+  readFileSvelte: 0,
+  readFileSvelteCacheHit: 0,
+  readFileSvelteTranslated: 0,
+  readFileSvelteFallback: 0,
+  readFileNonSvelte: 0,
+  primeCalls: 0,
+  primeSkippedNotInstalled: 0,
+  primeSkippedNoMtime: 0,
+  primeStored: 0,
+  rescans: 0,
+  patchAttempts: 0,
+  patchApplied: 0,
+};
+
+function debug(msg: string): void {
+  // eslint-disable-next-line no-process-env -- intentional opt-in gate
+  if (process.env[DEBUG_FLAG] !== "1") return;
+  process.stderr.write(`[svelte-eslint-parser:ts-sys-hook] ${msg}\n`);
+}
+
+function isDebug(): boolean {
+  // eslint-disable-next-line no-process-env -- intentional opt-in gate
+  return process.env[DEBUG_FLAG] === "1";
+}
 
 /** Called from `parseForESLint` so translation has the user's parser config. */
 export function rememberParserOptions(options: NormalizedParserOptions): void {
   activeParserOptions = options;
+
+  if (isDebug() && !firstParserOptionsLogged) {
+    firstParserOptionsLogged = true;
+    // `extraFileExtensions` lives on the raw options object; normalize spreads
+    // it through, even though it isn't part of the typed interface.
+    const raw = options as unknown as Record<string, unknown>;
+    const extra = raw.extraFileExtensions;
+    const hasSvelteExt =
+      Array.isArray(extra) && (extra as unknown[]).includes(".svelte");
+    debug(
+      `first parserOptions: ` +
+        `installed=${installed} ` +
+        `filePath=${options.filePath ?? "<none>"} ` +
+        `project=${
+          options.project == null ? "<none>" : JSON.stringify(options.project)
+        } ` +
+        `projectService=${
+          options.projectService == null
+            ? "<none>"
+            : JSON.stringify(options.projectService)
+        } ` +
+        `EXPERIMENTAL_useProjectService=${
+          options.EXPERIMENTAL_useProjectService == null
+            ? "<none>"
+            : JSON.stringify(options.EXPERIMENTAL_useProjectService)
+        } ` +
+        `extraFileExtensions=${
+          extra == null ? "<none>" : JSON.stringify(extra)
+        } ` +
+        `extraFileExtensions.includes('.svelte')=${hasSvelteExt}`,
+    );
+    if (!hasSvelteExt) {
+      debug(
+        "WARNING: parserOptions.extraFileExtensions does not include '.svelte'. " +
+          "ts.sys.readFile will not be called for .svelte paths, so the hook " +
+          "cannot speed anything up.",
+      );
+    }
+    if (
+      options.project == null &&
+      options.projectService == null &&
+      options.EXPERIMENTAL_useProjectService == null
+    ) {
+      debug(
+        "WARNING: neither project nor projectService is configured. The hook " +
+          "only helps when typescript-eslint is doing type-aware lint.",
+      );
+    }
+  }
+
   // Catch a TypeScript instance that landed in `require.cache` between
   // `installTsSysHook` and the first parse (e.g. typescript-eslint loaded
   // after svelte-eslint-parser in `eslint.config.js`). Walking on every
@@ -40,6 +121,8 @@ export function rememberParserOptions(options: NormalizedParserOptions): void {
   // are not added back later in a typical lint run.
   if (!needsParseTimeRescan) return;
   needsParseTimeRescan = false;
+  counters.rescans++;
+  debug("parse-time rescan triggered");
   patchAllLoadedTypeScripts();
 }
 
@@ -48,10 +131,20 @@ export function primeTranslationCache(
   filePath: string,
   virtualCode: string,
 ): void {
-  if (!installed) return;
+  counters.primeCalls++;
+  if (!installed) {
+    counters.primeSkippedNotInstalled++;
+    return;
+  }
   const mtimeMs = statMtimeMs(filePath);
-  if (mtimeMs === null) return;
+  if (mtimeMs === null) {
+    counters.primeSkippedNoMtime++;
+    debug(`primeTranslationCache: skipped (no mtime) ${filePath}`);
+    return;
+  }
   translations.set(filePath, { mtimeMs, virtualCode });
+  counters.primeStored++;
+  debug(`primeTranslationCache: stored ${filePath} (${virtualCode.length}B)`);
 }
 
 function statMtimeMs(filePath: string): number | null {
@@ -70,39 +163,75 @@ function readUtf8(filePath: string): string | null {
   }
 }
 
-function translateOnDemand(filePath: string): string | null {
-  if (!activeParserOptions) return null;
+type TranslateOutcome =
+  | { kind: "cache-hit"; virtualCode: string }
+  | { kind: "translated"; virtualCode: string }
+  | { kind: "no-parser-options" }
+  | { kind: "no-mtime" }
+  | { kind: "no-source" }
+  | { kind: "translation-failed" };
+
+function translateOnDemand(filePath: string): TranslateOutcome {
+  if (!activeParserOptions) return { kind: "no-parser-options" };
 
   const mtimeMs = statMtimeMs(filePath);
-  if (mtimeMs === null) return null;
+  if (mtimeMs === null) return { kind: "no-mtime" };
 
   const cached = translations.get(filePath);
-  if (cached && cached.mtimeMs === mtimeMs) return cached.virtualCode;
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return { kind: "cache-hit", virtualCode: cached.virtualCode };
+  }
 
   const svelteSource = readUtf8(filePath);
-  if (svelteSource === null) return null;
+  if (svelteSource === null) return { kind: "no-source" };
 
   const virtualCode = svelteToVirtualTypeScript(
     filePath,
     svelteSource,
     activeParserOptions,
   );
-  if (virtualCode === null) return null;
+  if (virtualCode === null) return { kind: "translation-failed" };
 
   translations.set(filePath, { mtimeMs, virtualCode });
-  return virtualCode;
+  return { kind: "translated", virtualCode };
 }
 
-function patchTsSys(sys: TsLike["sys"]): void {
-  if (!sys || typeof sys.readFile !== "function") return;
-  if (patchedSysObjects.has(sys)) return;
+function patchTsSys(sys: TsLike["sys"], origin: string): void {
+  counters.patchAttempts++;
+  if (!sys || typeof sys.readFile !== "function") {
+    debug(`patchTsSys: skipped (no sys.readFile) origin=${origin}`);
+    return;
+  }
+  if (patchedSysObjects.has(sys)) {
+    debug(`patchTsSys: skipped (already patched) origin=${origin}`);
+    return;
+  }
   patchedSysObjects.add(sys);
+  counters.patchApplied++;
+  debug(`patchTsSys: applied origin=${origin}`);
 
   const originalReadFile = sys.readFile.bind(sys);
   sys.readFile = (filePath: string, encoding?: string) => {
+    counters.readFileCalls++;
     if (typeof filePath === "string" && filePath.endsWith(".svelte")) {
-      const virtual = translateOnDemand(filePath);
-      if (virtual !== null) return virtual;
+      counters.readFileSvelte++;
+      const outcome = translateOnDemand(filePath);
+      switch (outcome.kind) {
+        case "cache-hit":
+          counters.readFileSvelteCacheHit++;
+          debug(`readFile: cache-hit ${filePath}`);
+          return outcome.virtualCode;
+        case "translated":
+          counters.readFileSvelteTranslated++;
+          debug(`readFile: translated ${filePath}`);
+          return outcome.virtualCode;
+        default:
+          counters.readFileSvelteFallback++;
+          debug(`readFile: fallback (${outcome.kind}) ${filePath}`);
+          break;
+      }
+    } else {
+      counters.readFileNonSvelte++;
     }
     return originalReadFile(filePath, encoding);
   };
@@ -116,9 +245,13 @@ function patchTsSys(sys: TsLike["sys"]): void {
 function ensureTypeScriptLoaded(): void {
   try {
     loadNewestModule<TsLike>("typescript");
-  } catch {
-    // TypeScript isn't installed in the project; the hook has nothing to
-    // patch and will simply be a no-op.
+    debug("ensureTypeScriptLoaded: ok");
+  } catch (e) {
+    debug(
+      `ensureTypeScriptLoaded: failed (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
   }
 }
 
@@ -127,28 +260,87 @@ function patchAllLoadedTypeScripts(): void {
   const cache = createRequire(import.meta.url).cache as
     | Record<string, { exports?: TsLike } | undefined>
     | undefined;
-  if (!cache) return;
+  if (!cache) {
+    debug("patchAllLoadedTypeScripts: require.cache unavailable");
+    return;
+  }
+  const matched: string[] = [];
   for (const [resolvedPath, mod] of Object.entries(cache)) {
     if (
       resolvedPath.includes(`${path.sep}typescript${path.sep}`) &&
       resolvedPath.endsWith(`${path.sep}typescript.js`)
     ) {
-      patchTsSys(mod?.exports?.sys);
+      matched.push(resolvedPath);
+      patchedTsPaths.add(resolvedPath);
+      patchTsSys(mod?.exports?.sys, resolvedPath);
     }
   }
+  debug(
+    `patchAllLoadedTypeScripts: scanned ${
+      Object.keys(cache).length
+    } entries, matched ${matched.length} typescript.js`,
+  );
+  for (const p of matched) debug(`  match: ${p}`);
 }
 
 /** Idempotent. No-op unless `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. */
 export function installTsSysHook(): void {
-  if (installed) return;
+  if (installed) {
+    debug("installTsSysHook: already installed");
+    return;
+  }
   // eslint-disable-next-line no-process-env -- intentional opt-in gate
-  if (process.env[ENV_FLAG] !== "1") return;
+  const envValue = process.env[ENV_FLAG];
+  if (envValue !== "1") {
+    debug(
+      `installTsSysHook: env flag ${ENV_FLAG}=${
+        envValue == null ? "<unset>" : JSON.stringify(envValue)
+      }, not installing`,
+    );
+    return;
+  }
 
+  debug(`installTsSysHook: ${ENV_FLAG}=1, installing`);
   ensureTypeScriptLoaded();
   patchAllLoadedTypeScripts();
   installed = true;
   // Arm a one-shot rescan; see `rememberParserOptions`.
   needsParseTimeRescan = true;
+
+  if (isDebug()) {
+    debug(
+      `installTsSysHook: complete. patched=${counters.patchApplied} ` +
+        `(skipped=${counters.patchAttempts - counters.patchApplied})`,
+    );
+    process.on("exit", () => {
+      debug(
+        `summary: readFile total=${counters.readFileCalls} ` +
+          `(.svelte=${counters.readFileSvelte}, non-.svelte=${counters.readFileNonSvelte})`,
+      );
+      debug(
+        `summary: .svelte readFile cache-hit=${counters.readFileSvelteCacheHit} ` +
+          `translated=${counters.readFileSvelteTranslated} ` +
+          `fallback=${counters.readFileSvelteFallback}`,
+      );
+      debug(
+        `summary: prime calls=${counters.primeCalls} stored=${counters.primeStored} ` +
+          `skip-not-installed=${counters.primeSkippedNotInstalled} ` +
+          `skip-no-mtime=${counters.primeSkippedNoMtime}`,
+      );
+      debug(
+        `summary: patch attempts=${counters.patchAttempts} applied=${counters.patchApplied} ` +
+          `rescans=${counters.rescans} ts-paths=${patchedTsPaths.size}`,
+      );
+      if (counters.readFileSvelte === 0) {
+        debug(
+          "summary: WARNING — ts.sys.readFile was never called for a .svelte path. " +
+            "Likely causes: parserOptions.extraFileExtensions missing '.svelte', " +
+            "typescript-eslint not running type-aware lint, " +
+            "or the TS instance it uses was not in CJS require.cache (e.g. ESM-loaded).",
+        );
+      }
+    });
+  }
 
   // Visible on every lint run so users know they opted into an experiment.
   process.stderr.write(

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -28,15 +28,18 @@ const translations = new Map<string, TranslationEntry>();
 const patchedSysObjects = new WeakSet();
 let activeParserOptions: NormalizedParserOptions | null = null;
 let installed = false;
+let needsParseTimeRescan = false;
 
 /** Called from `parseForESLint` so translation has the user's parser config. */
 export function rememberParserOptions(options: NormalizedParserOptions): void {
   activeParserOptions = options;
-  // Off when not installed: otherwise we'd patch TS instances loaded by
-  // unrelated tooling (e.g. svelte2tsx in `update-fixtures`).
-  if (!installed) return;
-  // Catch TypeScript instances loaded after `installTsSysHook` ran (peer
-  // resolution in non-hoisted monorepos).
+  // Catch a TypeScript instance that landed in `require.cache` between
+  // `installTsSysHook` and the first parse (e.g. typescript-eslint loaded
+  // after svelte-eslint-parser in `eslint.config.js`). Walking on every
+  // subsequent parse would be wasteful and gains nothing — TS instances
+  // are not added back later in a typical lint run.
+  if (!needsParseTimeRescan) return;
+  needsParseTimeRescan = false;
   patchAllLoadedTypeScripts();
 }
 
@@ -145,6 +148,8 @@ export function installTsSysHook(): void {
   if (ts?.sys) patchTsSys(ts.sys);
   patchAllLoadedTypeScripts();
   installed = true;
+  // Arm a one-shot rescan; see `rememberParserOptions`.
+  needsParseTimeRescan = true;
 
   // Visible on every lint run so users know they opted into an experiment.
   process.stderr.write(
@@ -157,4 +162,5 @@ export function installTsSysHook(): void {
 export function _resetTranslationCacheForTesting(): void {
   translations.clear();
   activeParserOptions = null;
+  needsParseTimeRescan = false;
 }

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -57,6 +57,12 @@ let installed = false;
  */
 export function rememberParserOptions(options: NormalizedParserOptions): void {
   activeParserOptions = options;
+  // Re-scanning `require.cache` is only safe — and only useful — once the
+  // hook is active. Without this guard we would patch every TS instance the
+  // moment any Svelte file is parsed, breaking unrelated tooling (e.g. the
+  // parser's own `update-fixtures` script, which relies on svelte2tsx's view
+  // of `.svelte` files, not ours).
+  if (!installed) return;
   // A late-loaded TypeScript instance (think: typescript-eslint resolving a
   // workspace-local TS after we already patched the root's) won't have
   // received the patch yet. Re-scan `require.cache` every parse so the next

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -9,10 +9,15 @@ import { loadNewestModule } from "./utils/cjs-module.js";
  * Experimental hook that intercepts `ts.sys.readFile` and returns virtual
  * TypeScript for `.svelte` paths. ESLint's own reads go through `fs` and
  * are unaffected. Activate with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`.
+ *
+ * Several preconditions must hold for the hook to actually speed anything up
+ * (extraFileExtensions includes '.svelte', type-aware lint is on, the TS
+ * instance is reachable through CJS require.cache). When the hook is opted
+ * in but a precondition fails, a warning is emitted so users can diagnose
+ * why no speed-up materialised.
  */
 
 const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
-const DEBUG_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK_DEBUG";
 
 interface TranslationEntry {
   mtimeMs: number;
@@ -27,91 +32,25 @@ interface TsLike {
 
 const translations = new Map<string, TranslationEntry>();
 const patchedSysObjects = new WeakSet();
-const patchedTsPaths = new Set<string>();
 let activeParserOptions: NormalizedParserOptions | null = null;
 let installed = false;
 let needsParseTimeRescan = false;
-let firstParserOptionsLogged = false;
+let parserOptionsInspected = false;
+let patchAppliedCount = 0;
+let primeStoredCount = 0;
+let svelteReadFileCount = 0;
 
-// Debug counters. Cheap when DEBUG flag is off; useful when on.
-const counters = {
-  readFileCalls: 0,
-  readFileSvelte: 0,
-  readFileSvelteCacheHit: 0,
-  readFileSvelteTranslated: 0,
-  readFileSvelteFallback: 0,
-  readFileNonSvelte: 0,
-  primeCalls: 0,
-  primeSkippedNotInstalled: 0,
-  primeSkippedNoMtime: 0,
-  primeStored: 0,
-  rescans: 0,
-  patchAttempts: 0,
-  patchApplied: 0,
-};
-
-function debug(msg: string): void {
-  // eslint-disable-next-line no-process-env -- intentional opt-in gate
-  if (process.env[DEBUG_FLAG] !== "1") return;
-  process.stderr.write(`[svelte-eslint-parser:ts-sys-hook] ${msg}\n`);
-}
-
-function isDebug(): boolean {
-  // eslint-disable-next-line no-process-env -- intentional opt-in gate
-  return process.env[DEBUG_FLAG] === "1";
+function warn(msg: string): void {
+  process.stderr.write(`[svelte-eslint-parser:ts-sys-hook] WARNING: ${msg}\n`);
 }
 
 /** Called from `parseForESLint` so translation has the user's parser config. */
 export function rememberParserOptions(options: NormalizedParserOptions): void {
   activeParserOptions = options;
 
-  if (isDebug() && !firstParserOptionsLogged) {
-    firstParserOptionsLogged = true;
-    // `extraFileExtensions` lives on the raw options object; normalize spreads
-    // it through, even though it isn't part of the typed interface.
-    const raw = options as unknown as Record<string, unknown>;
-    const extra = raw.extraFileExtensions;
-    const hasSvelteExt =
-      Array.isArray(extra) && (extra as unknown[]).includes(".svelte");
-    debug(
-      `first parserOptions: ` +
-        `installed=${installed} ` +
-        `filePath=${options.filePath ?? "<none>"} ` +
-        `project=${
-          options.project == null ? "<none>" : JSON.stringify(options.project)
-        } ` +
-        `projectService=${
-          options.projectService == null
-            ? "<none>"
-            : JSON.stringify(options.projectService)
-        } ` +
-        `EXPERIMENTAL_useProjectService=${
-          options.EXPERIMENTAL_useProjectService == null
-            ? "<none>"
-            : JSON.stringify(options.EXPERIMENTAL_useProjectService)
-        } ` +
-        `extraFileExtensions=${
-          extra == null ? "<none>" : JSON.stringify(extra)
-        } ` +
-        `extraFileExtensions.includes('.svelte')=${hasSvelteExt}`,
-    );
-    if (!hasSvelteExt) {
-      debug(
-        "WARNING: parserOptions.extraFileExtensions does not include '.svelte'. " +
-          "ts.sys.readFile will not be called for .svelte paths, so the hook " +
-          "cannot speed anything up.",
-      );
-    }
-    if (
-      options.project == null &&
-      options.projectService == null &&
-      options.EXPERIMENTAL_useProjectService == null
-    ) {
-      debug(
-        "WARNING: neither project nor projectService is configured. The hook " +
-          "only helps when typescript-eslint is doing type-aware lint.",
-      );
-    }
+  if (installed && !parserOptionsInspected) {
+    parserOptionsInspected = true;
+    inspectParserOptions(options);
   }
 
   // Catch a TypeScript instance that landed in `require.cache` between
@@ -121,9 +60,33 @@ export function rememberParserOptions(options: NormalizedParserOptions): void {
   // are not added back later in a typical lint run.
   if (!needsParseTimeRescan) return;
   needsParseTimeRescan = false;
-  counters.rescans++;
-  debug("parse-time rescan triggered");
   patchAllLoadedTypeScripts();
+}
+
+function inspectParserOptions(options: NormalizedParserOptions): void {
+  // `extraFileExtensions` lives on the raw options object; normalize spreads
+  // it through, even though it isn't part of the typed interface.
+  const raw = options as unknown as Record<string, unknown>;
+  const extra = raw.extraFileExtensions;
+  const hasSvelteExt =
+    Array.isArray(extra) && (extra as unknown[]).includes(".svelte");
+  if (!hasSvelteExt) {
+    warn(
+      "parserOptions.extraFileExtensions does not include '.svelte'. " +
+        "ts.sys.readFile will not be called for .svelte paths, so the hook " +
+        "cannot speed anything up.",
+    );
+  }
+  if (
+    options.project == null &&
+    options.projectService == null &&
+    options.EXPERIMENTAL_useProjectService == null
+  ) {
+    warn(
+      "neither `project` nor `projectService` is configured. The hook only " +
+        "helps when typescript-eslint is doing type-aware lint.",
+    );
+  }
 }
 
 /** Seed the cache so a later `ts.sys.readFile` skips re-translating. */
@@ -131,20 +94,11 @@ export function primeTranslationCache(
   filePath: string,
   virtualCode: string,
 ): void {
-  counters.primeCalls++;
-  if (!installed) {
-    counters.primeSkippedNotInstalled++;
-    return;
-  }
+  if (!installed) return;
   const mtimeMs = statMtimeMs(filePath);
-  if (mtimeMs === null) {
-    counters.primeSkippedNoMtime++;
-    debug(`primeTranslationCache: skipped (no mtime) ${filePath}`);
-    return;
-  }
+  if (mtimeMs === null) return;
   translations.set(filePath, { mtimeMs, virtualCode });
-  counters.primeStored++;
-  debug(`primeTranslationCache: stored ${filePath} (${virtualCode.length}B)`);
+  primeStoredCount++;
 }
 
 function statMtimeMs(filePath: string): number | null {
@@ -163,75 +117,41 @@ function readUtf8(filePath: string): string | null {
   }
 }
 
-type TranslateOutcome =
-  | { kind: "cache-hit"; virtualCode: string }
-  | { kind: "translated"; virtualCode: string }
-  | { kind: "no-parser-options" }
-  | { kind: "no-mtime" }
-  | { kind: "no-source" }
-  | { kind: "translation-failed" };
-
-function translateOnDemand(filePath: string): TranslateOutcome {
-  if (!activeParserOptions) return { kind: "no-parser-options" };
+function translateOnDemand(filePath: string): string | null {
+  if (!activeParserOptions) return null;
 
   const mtimeMs = statMtimeMs(filePath);
-  if (mtimeMs === null) return { kind: "no-mtime" };
+  if (mtimeMs === null) return null;
 
   const cached = translations.get(filePath);
-  if (cached && cached.mtimeMs === mtimeMs) {
-    return { kind: "cache-hit", virtualCode: cached.virtualCode };
-  }
+  if (cached && cached.mtimeMs === mtimeMs) return cached.virtualCode;
 
   const svelteSource = readUtf8(filePath);
-  if (svelteSource === null) return { kind: "no-source" };
+  if (svelteSource === null) return null;
 
   const virtualCode = svelteToVirtualTypeScript(
     filePath,
     svelteSource,
     activeParserOptions,
   );
-  if (virtualCode === null) return { kind: "translation-failed" };
+  if (virtualCode === null) return null;
 
   translations.set(filePath, { mtimeMs, virtualCode });
-  return { kind: "translated", virtualCode };
+  return virtualCode;
 }
 
-function patchTsSys(sys: TsLike["sys"], origin: string): void {
-  counters.patchAttempts++;
-  if (!sys || typeof sys.readFile !== "function") {
-    debug(`patchTsSys: skipped (no sys.readFile) origin=${origin}`);
-    return;
-  }
-  if (patchedSysObjects.has(sys)) {
-    debug(`patchTsSys: skipped (already patched) origin=${origin}`);
-    return;
-  }
+function patchTsSys(sys: TsLike["sys"]): void {
+  if (!sys || typeof sys.readFile !== "function") return;
+  if (patchedSysObjects.has(sys)) return;
   patchedSysObjects.add(sys);
-  counters.patchApplied++;
-  debug(`patchTsSys: applied origin=${origin}`);
+  patchAppliedCount++;
 
   const originalReadFile = sys.readFile.bind(sys);
   sys.readFile = (filePath: string, encoding?: string) => {
-    counters.readFileCalls++;
     if (typeof filePath === "string" && filePath.endsWith(".svelte")) {
-      counters.readFileSvelte++;
-      const outcome = translateOnDemand(filePath);
-      switch (outcome.kind) {
-        case "cache-hit":
-          counters.readFileSvelteCacheHit++;
-          debug(`readFile: cache-hit ${filePath}`);
-          return outcome.virtualCode;
-        case "translated":
-          counters.readFileSvelteTranslated++;
-          debug(`readFile: translated ${filePath}`);
-          return outcome.virtualCode;
-        default:
-          counters.readFileSvelteFallback++;
-          debug(`readFile: fallback (${outcome.kind}) ${filePath}`);
-          break;
-      }
-    } else {
-      counters.readFileNonSvelte++;
+      svelteReadFileCount++;
+      const virtual = translateOnDemand(filePath);
+      if (virtual !== null) return virtual;
     }
     return originalReadFile(filePath, encoding);
   };
@@ -245,12 +165,11 @@ function patchTsSys(sys: TsLike["sys"], origin: string): void {
 function ensureTypeScriptLoaded(): void {
   try {
     loadNewestModule<TsLike>("typescript");
-    debug("ensureTypeScriptLoaded: ok");
   } catch (e) {
-    debug(
-      `ensureTypeScriptLoaded: failed (${
+    warn(
+      `failed to load 'typescript' from the project: ${
         e instanceof Error ? e.message : String(e)
-      })`,
+      }. The hook has nothing to patch.`,
     );
   }
 }
@@ -260,87 +179,49 @@ function patchAllLoadedTypeScripts(): void {
   const cache = createRequire(import.meta.url).cache as
     | Record<string, { exports?: TsLike } | undefined>
     | undefined;
-  if (!cache) {
-    debug("patchAllLoadedTypeScripts: require.cache unavailable");
-    return;
-  }
-  const matched: string[] = [];
+  if (!cache) return;
   for (const [resolvedPath, mod] of Object.entries(cache)) {
     if (
       resolvedPath.includes(`${path.sep}typescript${path.sep}`) &&
       resolvedPath.endsWith(`${path.sep}typescript.js`)
     ) {
-      matched.push(resolvedPath);
-      patchedTsPaths.add(resolvedPath);
-      patchTsSys(mod?.exports?.sys, resolvedPath);
+      patchTsSys(mod?.exports?.sys);
     }
   }
-  debug(
-    `patchAllLoadedTypeScripts: scanned ${
-      Object.keys(cache).length
-    } entries, matched ${matched.length} typescript.js`,
-  );
-  for (const p of matched) debug(`  match: ${p}`);
 }
 
 /** Idempotent. No-op unless `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. */
 export function installTsSysHook(): void {
-  if (installed) {
-    debug("installTsSysHook: already installed");
-    return;
-  }
+  if (installed) return;
   // eslint-disable-next-line no-process-env -- intentional opt-in gate
-  const envValue = process.env[ENV_FLAG];
-  if (envValue !== "1") {
-    debug(
-      `installTsSysHook: env flag ${ENV_FLAG}=${
-        envValue == null ? "<unset>" : JSON.stringify(envValue)
-      }, not installing`,
-    );
-    return;
-  }
+  if (process.env[ENV_FLAG] !== "1") return;
 
-  debug(`installTsSysHook: ${ENV_FLAG}=1, installing`);
   ensureTypeScriptLoaded();
   patchAllLoadedTypeScripts();
   installed = true;
   // Arm a one-shot rescan; see `rememberParserOptions`.
   needsParseTimeRescan = true;
 
-  if (isDebug()) {
-    debug(
-      `installTsSysHook: complete. patched=${counters.patchApplied} ` +
-        `(skipped=${counters.patchAttempts - counters.patchApplied})`,
-    );
-    process.on("exit", () => {
-      debug(
-        `summary: readFile total=${counters.readFileCalls} ` +
-          `(.svelte=${counters.readFileSvelte}, non-.svelte=${counters.readFileNonSvelte})`,
+  // End-of-run check: if .svelte files were linted but the patched readFile
+  // was never hit for any of them, the hook silently did nothing.
+  process.on("exit", () => {
+    if (primeStoredCount > 0 && svelteReadFileCount === 0) {
+      warn(
+        "ts.sys.readFile was never called for a .svelte path even though " +
+          `${primeStoredCount} .svelte file(s) were parsed. Likely causes: ` +
+          "parserOptions.extraFileExtensions missing '.svelte', " +
+          "typescript-eslint not running type-aware lint, " +
+          "or the TS instance it uses was not in CJS require.cache " +
+          "(e.g. ESM-loaded).",
       );
-      debug(
-        `summary: .svelte readFile cache-hit=${counters.readFileSvelteCacheHit} ` +
-          `translated=${counters.readFileSvelteTranslated} ` +
-          `fallback=${counters.readFileSvelteFallback}`,
+    } else if (patchAppliedCount === 0) {
+      warn(
+        "no `typescript.js` was found in CJS require.cache, so nothing was " +
+          "patched. The TS instance used by typescript-eslint may be " +
+          "ESM-loaded or otherwise outside the cache.",
       );
-      debug(
-        `summary: prime calls=${counters.primeCalls} stored=${counters.primeStored} ` +
-          `skip-not-installed=${counters.primeSkippedNotInstalled} ` +
-          `skip-no-mtime=${counters.primeSkippedNoMtime}`,
-      );
-      debug(
-        `summary: patch attempts=${counters.patchAttempts} applied=${counters.patchApplied} ` +
-          `rescans=${counters.rescans} ts-paths=${patchedTsPaths.size}`,
-      );
-      if (counters.readFileSvelte === 0) {
-        debug(
-          "summary: WARNING — ts.sys.readFile was never called for a .svelte path. " +
-            "Likely causes: parserOptions.extraFileExtensions missing '.svelte', " +
-            "typescript-eslint not running type-aware lint, " +
-            "or the TS instance it uses was not in CJS require.cache (e.g. ESM-loaded).",
-        );
-      }
-    });
-  }
+    }
+  });
 
   // Visible on every lint run so users know they opted into an experiment.
   process.stderr.write(

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -244,3 +244,8 @@ export function _resetTranslationCacheForTesting(): void {
   activeParserOptions = null;
   needsParseTimeRescan = false;
 }
+
+/** Test seam: patch a caller-supplied `sys` instead of the require.cache ones. */
+export function _patchTsSysForTesting(sys: TsLike["sys"]): void {
+  patchTsSys(sys);
+}

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -1,9 +1,9 @@
 import fs from "fs";
 import path from "path";
 import { createRequire } from "module";
-import { fileURLToPath } from "url";
 import type { NormalizedParserOptions } from "./parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "./parser/svelte-to-virtual-ts.js";
+import { loadNewestModule } from "./utils/cjs-module.js";
 
 /**
  * Experimental hook that intercepts `ts.sys.readFile` and returns virtual
@@ -97,25 +97,14 @@ function patchTsSys(sys: TsLike["sys"]): void {
   };
 }
 
-/** Resolve TypeScript from the user's project (cwd → here → self). */
+/**
+ * Resolve TypeScript using the parser's shared loader, which tries the
+ * linter's require first (matching what typescript-eslint resolves) before
+ * falling back to cwd and this package.
+ */
 function loadProjectTypeScript(): TsLike | null {
-  const here =
-    typeof __dirname !== "undefined"
-      ? __dirname
-      : path.dirname(fileURLToPath(import.meta.url));
-  const requireRoots = [
-    path.join(process.cwd(), "package.json"),
-    path.join(here, "package.json"),
-  ];
-  for (const requireRoot of requireRoots) {
-    try {
-      return createRequire(requireRoot)("typescript") as TsLike;
-    } catch {
-      // try next root
-    }
-  }
   try {
-    return createRequire(import.meta.url)("typescript") as TsLike;
+    return loadNewestModule<TsLike>("typescript");
   } catch {
     return null;
   }

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -154,7 +154,7 @@ export function installTsSysHook(): void {
   // Visible on every lint run so users know they opted into an experiment.
   process.stderr.write(
     `[svelte-eslint-parser] ${ENV_FLAG}=1 enables an experimental ts.sys.readFile hook. ` +
-      `Behaviour and API may change or be removed in any release.\n`,
+      `Behavior and API may change or be removed in any release.\n`,
   );
 }
 

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -17,19 +17,26 @@ import { svelteToVirtualTypeScript } from "./parser/svelte-to-virtual-ts.js";
  * Activation:
  *   `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`
  *
- * Limitations to be aware of:
- *   - Lint rules that surface raw TypeScript diagnostics
- *     (e.g. `program.getSemanticDiagnostics(sourceFile)`) will report
- *     positions that index into the virtual TS, not the original Svelte
- *     source. Type-aware rules that go through the parser's AST positions
- *     via `services.getTypeAtLocation(node)` are unaffected.
- *   - In monorepos that install multiple TypeScript packages without
- *     hoisting, `@typescript-eslint/parser` may resolve to a TS instance
- *     this module hasn't patched. The hook patches every TS already in
+ * Notes on positions:
+ *   - Type-aware lint of `.svelte` files always works against the parser's
+ *     virtual TypeScript shim. `services.getTypeAtLocation(node)` is fine
+ *     because the parser restores node positions to the Svelte source,
+ *     but rules that read raw TS diagnostics
+ *     (`program.getSemanticDiagnostics(sourceFile)` and friends) see
+ *     positions inside the shim. The hook does not change this — the
+ *     diagnostics would already be in shim coordinates without it, because
+ *     TypeScript only ever sees the shim either way. What the hook does
+ *     improve is cross-file resolution: a sibling `import './Other.svelte'`
+ *     resolves to real virtual TypeScript instead of opaque
+ *     `declare module '*.svelte'`.
+ *
+ * Monorepo notes:
+ *   - In layouts that install multiple TypeScript packages without
+ *     hoisting, `@typescript-eslint/parser` may resolve a TS instance this
+ *     module hasn't patched. The hook patches every TS already in
  *     `require.cache` at install time and re-scans on every parse, but a
  *     freshly imported peer TS between parses may slip through until the
- *     next call. Workspace-isolated TS installs should mirror what
- *     typescript-eslint resolves; if they don't, document it for users.
+ *     next call.
  */
 
 const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -21,7 +21,9 @@ const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
 
 interface TranslationEntry {
   mtimeMs: number;
-  virtualCode: string;
+  // `null` means "no virtual translation at this mtime" — a negative cache
+  // so JS-only `.svelte` files don't pay a full Svelte parse on every read.
+  virtualCode: string | null;
 }
 
 interface TsLike {
@@ -95,6 +97,10 @@ export function primeTranslationCache(
   virtualCode: string,
 ): void {
   if (!installed) return;
+  // Skip the stat + write if on-demand translation already cached a positive
+  // entry — the prime is redundant when ts.sys read the file before ESLint did.
+  const existing = translations.get(filePath);
+  if (existing && existing.virtualCode !== null) return;
   const mtimeMs = statMtimeMs(filePath);
   if (mtimeMs === null) return;
   translations.set(filePath, { mtimeMs, virtualCode });
@@ -127,15 +133,17 @@ function translateOnDemand(filePath: string): string | null {
   if (cached && cached.mtimeMs === mtimeMs) return cached.virtualCode;
 
   const svelteSource = readUtf8(filePath);
-  if (svelteSource === null) return null;
+  if (svelteSource === null) {
+    translations.set(filePath, { mtimeMs, virtualCode: null });
+    return null;
+  }
 
   const virtualCode = svelteToVirtualTypeScript(
     filePath,
     svelteSource,
     activeParserOptions,
   );
-  if (virtualCode === null) return null;
-
+  // Store the outcome — including `null` — to negative-cache failed translations.
   translations.set(filePath, { mtimeMs, virtualCode });
   return virtualCode;
 }

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -1,0 +1,205 @@
+import fs from "fs";
+import path from "path";
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import type { NormalizedParserOptions } from "./parser/parser-options.js";
+import { svelteToVirtualTypeScript } from "./parser/svelte-to-virtual-ts.js";
+
+/**
+ * In-memory bridge that lets TypeScript's projectService type-check Svelte
+ * files without any on-disk artifacts.
+ *
+ * When installed, the hook intercepts `ts.sys.readFile`. For paths ending in
+ * `.svelte`, it converts the source to virtual TypeScript on demand and
+ * returns that string. Every other read passes through untouched, so
+ * ESLint's own file reads still see the original Svelte source.
+ *
+ * Activation:
+ *   `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`
+ *
+ * Limitations to be aware of:
+ *   - Lint rules that surface raw TypeScript diagnostics
+ *     (e.g. `program.getSemanticDiagnostics(sourceFile)`) will report
+ *     positions that index into the virtual TS, not the original Svelte
+ *     source. Type-aware rules that go through the parser's AST positions
+ *     via `services.getTypeAtLocation(node)` are unaffected.
+ *   - In monorepos that install multiple TypeScript packages without
+ *     hoisting, `@typescript-eslint/parser` may resolve to a TS instance
+ *     this module hasn't patched. The hook patches every TS already in
+ *     `require.cache` at install time and re-scans on every parse, but a
+ *     freshly imported peer TS between parses may slip through until the
+ *     next call. Workspace-isolated TS installs should mirror what
+ *     typescript-eslint resolves; if they don't, document it for users.
+ */
+
+const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
+
+interface TranslationEntry {
+  mtimeMs: number;
+  virtualCode: string;
+}
+
+interface TsLike {
+  sys?: {
+    readFile?: (path: string, encoding?: string) => string | undefined;
+  };
+}
+
+const translations = new Map<string, TranslationEntry>();
+const patchedSysObjects = new WeakSet();
+let activeParserOptions: NormalizedParserOptions | null = null;
+let installed = false;
+
+/**
+ * Record the parser options ESLint just normalized. Translation needs them
+ * (parser, svelteFeatures, sourceType, ecmaVersion, ...); the parse entry
+ * point is the only place they flow through.
+ */
+export function rememberParserOptions(options: NormalizedParserOptions): void {
+  activeParserOptions = options;
+  // A late-loaded TypeScript instance (think: typescript-eslint resolving a
+  // workspace-local TS after we already patched the root's) won't have
+  // received the patch yet. Re-scan `require.cache` every parse so the next
+  // TS instance to surface gets a chance to be patched.
+  patchAllLoadedTypeScripts();
+}
+
+function statMtimeMs(filePath: string): number | null {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function readUtf8(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function translateOnDemand(filePath: string): string | null {
+  if (!activeParserOptions) return null;
+
+  const mtimeMs = statMtimeMs(filePath);
+  if (mtimeMs === null) return null;
+
+  const cached = translations.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.virtualCode;
+
+  const svelteSource = readUtf8(filePath);
+  if (svelteSource === null) return null;
+
+  const virtualCode = svelteToVirtualTypeScript(
+    filePath,
+    svelteSource,
+    activeParserOptions,
+  );
+  if (virtualCode === null) return null;
+
+  translations.set(filePath, { mtimeMs, virtualCode });
+  return virtualCode;
+}
+
+function patchTsSys(sys: TsLike["sys"]): void {
+  if (!sys || typeof sys.readFile !== "function") return;
+  if (patchedSysObjects.has(sys)) return;
+  patchedSysObjects.add(sys);
+
+  const originalReadFile = sys.readFile.bind(sys);
+  sys.readFile = (filePath: string, encoding?: string) => {
+    if (typeof filePath === "string" && filePath.endsWith(".svelte")) {
+      const virtual = translateOnDemand(filePath);
+      if (virtual !== null) return virtual;
+    }
+    return originalReadFile(filePath, encoding);
+  };
+}
+
+/**
+ * Try to resolve and load TypeScript from the user's project so we end up
+ * patching the same instance `@typescript-eslint/parser` will later use.
+ *
+ * Resolution order:
+ *   1. `process.cwd()` — where the user runs ESLint from. Matches what
+ *      tools resolving "the project's TypeScript" do by convention.
+ *   2. The directory containing this module — works when this package and
+ *      `typescript` are hoisted together.
+ *   3. `import.meta.url` — last-resort relative to our own location.
+ */
+function loadProjectTypeScript(): TsLike | null {
+  const here =
+    typeof __dirname !== "undefined"
+      ? __dirname
+      : path.dirname(fileURLToPath(import.meta.url));
+  const requireRoots = [
+    path.join(process.cwd(), "package.json"),
+    path.join(here, "package.json"),
+  ];
+  for (const requireRoot of requireRoots) {
+    try {
+      return createRequire(requireRoot)("typescript") as TsLike;
+    } catch {
+      // try next root
+    }
+  }
+  try {
+    return createRequire(import.meta.url)("typescript") as TsLike;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk Node's `require.cache` looking for any already-loaded TypeScript
+ * module and patch its `sys.readFile`. Catches the (uncommon but real) case
+ * where typescript-eslint has resolved a TS instance we didn't.
+ */
+function patchAllLoadedTypeScripts(): void {
+  const req = createRequire(import.meta.url);
+  const cache = (req as unknown as { cache?: Record<string, NodeModule> })
+    .cache;
+  if (!cache) return;
+  for (const [resolvedPath, mod] of Object.entries(cache)) {
+    if (
+      resolvedPath.includes(`${path.sep}typescript${path.sep}`) &&
+      resolvedPath.endsWith(`${path.sep}typescript.js`)
+    ) {
+      const exports = (mod as { exports?: TsLike } | undefined)?.exports;
+      patchTsSys(exports?.sys);
+    }
+  }
+}
+
+/**
+ * Install the `ts.sys.readFile` patch. Idempotent. No-op unless
+ * `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1` is set.
+ *
+ * Two passes: load TypeScript from the user's project explicitly (so it
+ * lands in `require.cache` and projectService later finds the patched
+ * instance), then walk `require.cache` for any other TS instance that may
+ * already be loaded.
+ */
+export function installTsSysHook(): void {
+  if (installed) return;
+  // eslint-disable-next-line no-process-env -- intentional opt-in gate
+  if (process.env[ENV_FLAG] !== "1") return;
+
+  const ts = loadProjectTypeScript();
+  if (ts?.sys) patchTsSys(ts.sys);
+  patchAllLoadedTypeScripts();
+  installed = true;
+}
+
+/**
+ * Test seam — clears the in-memory translation cache. The `ts.sys` patches
+ * themselves are intentionally not removable; restoring would require
+ * holding the original references for every TS instance and is unnecessary
+ * for our use case (parser-lifetime install).
+ */
+export function _resetTranslationCacheForTesting(): void {
+  translations.clear();
+  activeParserOptions = null;
+}

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -43,6 +43,23 @@ export function rememberParserOptions(options: NormalizedParserOptions): void {
   patchAllLoadedTypeScripts();
 }
 
+/**
+ * Seed the translation cache from the parser's own pipeline. The parser
+ * already produces virtual TS for the file it is currently parsing;
+ * stashing it here lets `ts.sys.readFile` serve the same string without
+ * re-running `analyzeTypeScriptInSvelte` if `projectService` later reaches
+ * for the file on disk.
+ */
+export function primeTranslationCache(
+  filePath: string,
+  virtualCode: string,
+): void {
+  if (!installed) return;
+  const mtimeMs = statMtimeMs(filePath);
+  if (mtimeMs === null) return;
+  translations.set(filePath, { mtimeMs, virtualCode });
+}
+
 function statMtimeMs(filePath: string): number | null {
   try {
     return fs.statSync(filePath).mtimeMs;

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -8,7 +8,7 @@ import { loadNewestModule } from "./utils/cjs-module.js";
 /**
  * Experimental hook that intercepts `ts.sys.readFile` and returns virtual
  * TypeScript for `.svelte` paths. ESLint's own reads go through `fs` and
- * are unaffected. Activate with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`.
+ * are unaffected. Activate with `SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`.
  *
  * Several preconditions must hold for the hook to actually speed anything up
  * (extraFileExtensions includes '.svelte', type-aware lint is on, the TS
@@ -17,7 +17,7 @@ import { loadNewestModule } from "./utils/cjs-module.js";
  * why no speed-up materialised.
  */
 
-const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
+const ENV_FLAG = "SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK";
 
 interface TranslationEntry {
   mtimeMs: number;
@@ -198,7 +198,7 @@ function patchAllLoadedTypeScripts(): void {
   }
 }
 
-/** Idempotent. No-op unless `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. */
+/** Idempotent. No-op unless `SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`. */
 export function installTsSysHook(): void {
   if (installed) return;
   // eslint-disable-next-line no-process-env -- intentional opt-in gate

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -6,37 +6,9 @@ import type { NormalizedParserOptions } from "./parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "./parser/svelte-to-virtual-ts.js";
 
 /**
- * In-memory bridge that lets TypeScript's projectService type-check Svelte
- * files without any on-disk artifacts.
- *
- * When installed, the hook intercepts `ts.sys.readFile`. For paths ending in
- * `.svelte`, it converts the source to virtual TypeScript on demand and
- * returns that string. Every other read passes through untouched, so
- * ESLint's own file reads still see the original Svelte source.
- *
- * Activation:
- *   `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`
- *
- * Notes on positions:
- *   - Type-aware lint of `.svelte` files always works against the parser's
- *     virtual TypeScript shim. `services.getTypeAtLocation(node)` is fine
- *     because the parser restores node positions to the Svelte source,
- *     but rules that read raw TS diagnostics
- *     (`program.getSemanticDiagnostics(sourceFile)` and friends) see
- *     positions inside the shim. The hook does not change this — the
- *     diagnostics would already be in shim coordinates without it, because
- *     TypeScript only ever sees the shim either way. What the hook does
- *     improve is cross-file resolution: a sibling `import './Other.svelte'`
- *     resolves to real virtual TypeScript instead of opaque
- *     `declare module '*.svelte'`.
- *
- * Monorepo notes:
- *   - In layouts that install multiple TypeScript packages without
- *     hoisting, `@typescript-eslint/parser` may resolve a TS instance this
- *     module hasn't patched. The hook patches every TS already in
- *     `require.cache` at install time and re-scans on every parse, but a
- *     freshly imported peer TS between parses may slip through until the
- *     next call.
+ * Experimental hook that intercepts `ts.sys.readFile` and returns virtual
+ * TypeScript for `.svelte` paths. ESLint's own reads go through `fs` and
+ * are unaffected. Activate with `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`.
  */
 
 const ENV_FLAG = "SVELTE_ESLINT_PARSER_TS_SYS_HOOK";
@@ -57,23 +29,14 @@ const patchedSysObjects = new WeakSet();
 let activeParserOptions: NormalizedParserOptions | null = null;
 let installed = false;
 
-/**
- * Record the parser options ESLint just normalized. Translation needs them
- * (parser, svelteFeatures, sourceType, ecmaVersion, ...); the parse entry
- * point is the only place they flow through.
- */
+/** Called from `parseForESLint` so translation has the user's parser config. */
 export function rememberParserOptions(options: NormalizedParserOptions): void {
   activeParserOptions = options;
-  // Re-scanning `require.cache` is only safe — and only useful — once the
-  // hook is active. Without this guard we would patch every TS instance the
-  // moment any Svelte file is parsed, breaking unrelated tooling (e.g. the
-  // parser's own `update-fixtures` script, which relies on svelte2tsx's view
-  // of `.svelte` files, not ours).
+  // Off when not installed: otherwise we'd patch TS instances loaded by
+  // unrelated tooling (e.g. svelte2tsx in `update-fixtures`).
   if (!installed) return;
-  // A late-loaded TypeScript instance (think: typescript-eslint resolving a
-  // workspace-local TS after we already patched the root's) won't have
-  // received the patch yet. Re-scan `require.cache` every parse so the next
-  // TS instance to surface gets a chance to be patched.
+  // Catch TypeScript instances loaded after `installTsSysHook` ran (peer
+  // resolution in non-hoisted monorepos).
   patchAllLoadedTypeScripts();
 }
 
@@ -131,17 +94,7 @@ function patchTsSys(sys: TsLike["sys"]): void {
   };
 }
 
-/**
- * Try to resolve and load TypeScript from the user's project so we end up
- * patching the same instance `@typescript-eslint/parser` will later use.
- *
- * Resolution order:
- *   1. `process.cwd()` — where the user runs ESLint from. Matches what
- *      tools resolving "the project's TypeScript" do by convention.
- *   2. The directory containing this module — works when this package and
- *      `typescript` are hoisted together.
- *   3. `import.meta.url` — last-resort relative to our own location.
- */
+/** Resolve TypeScript from the user's project (cwd → here → self). */
 function loadProjectTypeScript(): TsLike | null {
   const here =
     typeof __dirname !== "undefined"
@@ -165,11 +118,7 @@ function loadProjectTypeScript(): TsLike | null {
   }
 }
 
-/**
- * Walk Node's `require.cache` looking for any already-loaded TypeScript
- * module and patch its `sys.readFile`. Catches the (uncommon but real) case
- * where typescript-eslint has resolved a TS instance we didn't.
- */
+/** Patch every `typescript.js` already in `require.cache`. */
 function patchAllLoadedTypeScripts(): void {
   const req = createRequire(import.meta.url);
   const cache = (req as unknown as { cache?: Record<string, NodeModule> })
@@ -186,15 +135,7 @@ function patchAllLoadedTypeScripts(): void {
   }
 }
 
-/**
- * Install the `ts.sys.readFile` patch. Idempotent. No-op unless
- * `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1` is set.
- *
- * Two passes: load TypeScript from the user's project explicitly (so it
- * lands in `require.cache` and projectService later finds the patched
- * instance), then walk `require.cache` for any other TS instance that may
- * already be loaded.
- */
+/** Idempotent. No-op unless `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`. */
 export function installTsSysHook(): void {
   if (installed) return;
   // eslint-disable-next-line no-process-env -- intentional opt-in gate
@@ -205,20 +146,14 @@ export function installTsSysHook(): void {
   patchAllLoadedTypeScripts();
   installed = true;
 
-  // Surface the experimental status at runtime. `eslint --quiet` does not
-  // filter stderr, so users running the hook will see this on every lint.
+  // Visible on every lint run so users know they opted into an experiment.
   process.stderr.write(
     `[svelte-eslint-parser] ${ENV_FLAG}=1 enables an experimental ts.sys.readFile hook. ` +
       `Behaviour and API may change or be removed in any release.\n`,
   );
 }
 
-/**
- * Test seam — clears the in-memory translation cache. The `ts.sys` patches
- * themselves are intentionally not removable; restoring would require
- * holding the original references for every TS instance and is unnecessary
- * for our use case (parser-lifetime install).
- */
+/** Test seam. The `ts.sys` patches themselves are intentionally permanent. */
 export function _resetTranslationCacheForTesting(): void {
   translations.clear();
   activeParserOptions = null;

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -98,31 +98,31 @@ function patchTsSys(sys: TsLike["sys"]): void {
 }
 
 /**
- * Resolve TypeScript using the parser's shared loader, which tries the
- * linter's require first (matching what typescript-eslint resolves) before
- * falling back to cwd and this package.
+ * Force-load the project's TypeScript so it lands in `require.cache`. The
+ * patch then happens through `patchAllLoadedTypeScripts`; no need to capture
+ * the returned module ourselves.
  */
-function loadProjectTypeScript(): TsLike | null {
+function ensureTypeScriptLoaded(): void {
   try {
-    return loadNewestModule<TsLike>("typescript");
+    loadNewestModule<TsLike>("typescript");
   } catch {
-    return null;
+    // TypeScript isn't installed in the project; the hook has nothing to
+    // patch and will simply be a no-op.
   }
 }
 
 /** Patch every `typescript.js` already in `require.cache`. */
 function patchAllLoadedTypeScripts(): void {
-  const req = createRequire(import.meta.url);
-  const cache = (req as unknown as { cache?: Record<string, NodeModule> })
-    .cache;
+  const cache = createRequire(import.meta.url).cache as
+    | Record<string, { exports?: TsLike } | undefined>
+    | undefined;
   if (!cache) return;
   for (const [resolvedPath, mod] of Object.entries(cache)) {
     if (
       resolvedPath.includes(`${path.sep}typescript${path.sep}`) &&
       resolvedPath.endsWith(`${path.sep}typescript.js`)
     ) {
-      const exports = (mod as { exports?: TsLike } | undefined)?.exports;
-      patchTsSys(exports?.sys);
+      patchTsSys(mod?.exports?.sys);
     }
   }
 }
@@ -133,8 +133,7 @@ export function installTsSysHook(): void {
   // eslint-disable-next-line no-process-env -- intentional opt-in gate
   if (process.env[ENV_FLAG] !== "1") return;
 
-  const ts = loadProjectTypeScript();
-  if (ts?.sys) patchTsSys(ts.sys);
+  ensureTypeScriptLoaded();
   patchAllLoadedTypeScripts();
   installed = true;
   // Arm a one-shot rescan; see `rememberParserOptions`.

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -197,6 +197,13 @@ export function installTsSysHook(): void {
   if (ts?.sys) patchTsSys(ts.sys);
   patchAllLoadedTypeScripts();
   installed = true;
+
+  // Surface the experimental status at runtime. `eslint --quiet` does not
+  // filter stderr, so users running the hook will see this on every lint.
+  process.stderr.write(
+    `[svelte-eslint-parser] ${ENV_FLAG}=1 enables an experimental ts.sys.readFile hook. ` +
+      `Behaviour and API may change or be removed in any release.\n`,
+  );
 }
 
 /**

--- a/src/utils/cjs-module.ts
+++ b/src/utils/cjs-module.ts
@@ -8,7 +8,10 @@ const cachedRequires: {
 } = {};
 
 /**
- * Get the newest `espree` kind from the loaded ESLint or dependency.
+ * Load the given module from the user's environment, picking the newest
+ * version when more than one is reachable. Tries the linter's require
+ * first (so we match what ESLint and its parsers resolve), then cwd,
+ * then this package.
  */
 export function loadNewestModule<T>(module: string): T {
   const requires = [

--- a/src/utils/cjs-module.ts
+++ b/src/utils/cjs-module.ts
@@ -7,12 +7,7 @@ const cachedRequires: {
   fromCwd?: NodeJS.Require;
 } = {};
 
-/**
- * Load the given module from the user's environment, picking the newest
- * version when more than one is reachable. Tries the linter's require
- * first (so we match what ESLint and its parsers resolve), then cwd,
- * then this package.
- */
+/** Load the newest reachable copy of a module (linter → cwd → self). */
 export function loadNewestModule<T>(module: string): T {
   const requires = [
     getRequireFromLinter(),

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -1,0 +1,103 @@
+import assert from "assert";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { normalizeParserOptions } from "../../src/parser/parser-options.js";
+import { svelteToVirtualTypeScript } from "../../src/parser/svelte-to-virtual-ts.js";
+import {
+  _resetTranslationCacheForTesting,
+  rememberParserOptions,
+} from "../../src/ts-sys-hook.js";
+
+const TS_SCRIPT = `<script lang="ts">
+  let count: number = 0;
+  function inc(): void { count += 1; }
+</script>
+<button onclick={inc}>{count}</button>
+`;
+
+const JS_SCRIPT = `<script>
+  let count = 0;
+</script>
+<button>{count}</button>
+`;
+
+function withTempSvelteFile(
+  source: string,
+  body: (filePath: string) => void,
+): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ts-sys-hook-"));
+  const filePath = path.join(dir, "Component.svelte");
+  fs.writeFileSync(filePath, source, "utf-8");
+  try {
+    body(filePath);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeParserOptions(filePath: string) {
+  return normalizeParserOptions({
+    filePath,
+    parser: "@typescript-eslint/parser",
+    ecmaVersion: 2024,
+    sourceType: "module",
+  });
+}
+
+describe("svelteToVirtualTypeScript", () => {
+  it("returns a virtual TypeScript string for a `<script lang='ts'>` block", () => {
+    withTempSvelteFile(TS_SCRIPT, (filePath) => {
+      const code = svelteToVirtualTypeScript(
+        filePath,
+        TS_SCRIPT,
+        makeParserOptions(filePath),
+      );
+      assert.notStrictEqual(code, null, "expected non-null translation");
+      assert.match(
+        code!,
+        /let count: number/,
+        "expected the user's TS source to appear in the shim",
+      );
+    });
+  });
+
+  it("returns null when the script block isn't TypeScript", () => {
+    withTempSvelteFile(JS_SCRIPT, (filePath) => {
+      const code = svelteToVirtualTypeScript(
+        filePath,
+        JS_SCRIPT,
+        makeParserOptions(filePath),
+      );
+      assert.strictEqual(code, null);
+    });
+  });
+
+  it("returns null when the source cannot be parsed", () => {
+    const broken = `<script lang="ts">let x: number =</script>`;
+    withTempSvelteFile(broken, (filePath) => {
+      const code = svelteToVirtualTypeScript(
+        filePath,
+        broken,
+        makeParserOptions(filePath),
+      );
+      assert.strictEqual(code, null);
+    });
+  });
+});
+
+describe("rememberParserOptions", () => {
+  beforeEach(() => {
+    _resetTranslationCacheForTesting();
+  });
+
+  it("accepts and discards options without throwing", () => {
+    // The hook is a global side-effect; we mostly want to confirm the public
+    // priming call is safe to call in any state.
+    withTempSvelteFile(TS_SCRIPT, (filePath) => {
+      assert.doesNotThrow(() => {
+        rememberParserOptions(makeParserOptions(filePath));
+      });
+    });
+  });
+});

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { normalizeParserOptions } from "../../src/parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "../../src/parser/svelte-to-virtual-ts.js";
 import {
+  _patchTsSysForTesting,
   _resetTranslationCacheForTesting,
   rememberParserOptions,
 } from "../../src/ts-sys-hook.js";
@@ -98,6 +99,66 @@ describe("rememberParserOptions", () => {
       assert.doesNotThrow(() => {
         rememberParserOptions(makeParserOptions(filePath));
       });
+    });
+  });
+});
+
+describe("ts.sys.readFile hook wiring", () => {
+  beforeEach(() => {
+    _resetTranslationCacheForTesting();
+  });
+
+  it("returns the virtual shim for a .svelte path once the sys is patched", () => {
+    withTempSvelteFile(TS_SCRIPT, (filePath) => {
+      // Track original-readFile calls to prove the hook short-circuits.
+      const passthrough: string[] = [];
+      const sys = {
+        readFile: (p: string) => {
+          passthrough.push(p);
+          return fs.readFileSync(p, "utf-8");
+        },
+      };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(filePath));
+
+      const result = sys.readFile(filePath);
+      assert.match(result, /let count: number/, "expected the virtual TS shim");
+      assert.deepStrictEqual(
+        passthrough,
+        [],
+        "original readFile must be bypassed for a translatable .svelte path",
+      );
+    });
+  });
+
+  it("falls through to the original readFile for non-.svelte paths", () => {
+    withTempSvelteFile(TS_SCRIPT, (filePath) => {
+      const tsPath = path.join(path.dirname(filePath), "other.ts");
+      fs.writeFileSync(tsPath, "export const x: number = 1;\n", "utf-8");
+      const sys = { readFile: (p: string) => fs.readFileSync(p, "utf-8") };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(filePath));
+
+      assert.strictEqual(sys.readFile(tsPath), "export const x: number = 1;\n");
+    });
+  });
+
+  it("falls through for a JS-only .svelte file (nothing to translate)", () => {
+    withTempSvelteFile(JS_SCRIPT, (filePath) => {
+      const sys = { readFile: (p: string) => fs.readFileSync(p, "utf-8") };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(filePath));
+
+      assert.strictEqual(sys.readFile(filePath), JS_SCRIPT);
+    });
+  });
+
+  it("does nothing before rememberParserOptions sets options", () => {
+    withTempSvelteFile(TS_SCRIPT, (filePath) => {
+      const sys = { readFile: (p: string) => fs.readFileSync(p, "utf-8") };
+      _patchTsSysForTesting(sys);
+
+      assert.strictEqual(sys.readFile(filePath), TS_SCRIPT);
     });
   });
 });


### PR DESCRIPTION
close https://github.com/sveltejs/svelte-eslint-parser/issues/768
close https://github.com/sveltejs/svelte-eslint-parser/issues/722
close https://github.com/sveltejs/eslint-plugin-svelte/issues/1084

## Summary

Adds an experimental `ts.sys.readFile` hook so `@typescript-eslint/parser`'s `projectService: true` can type-check `.svelte` files through the user's existing `tsconfig.json` — no separate program, no extra configuration, no on-disk artifacts. Opt in with the environment variable `SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1`.

When the hook installs (at module load, gated by the env flag) it:

1. Resolves the project's `typescript` through the parser's shared `loadNewestModule` (linter → cwd → self), then patches every `typescript.js` already in `require.cache`. A one-shot rescan on the first `parseForESLint` catches a TS instance that was loaded between install and that first parse.
2. Memoises translations by `(path, mtime)` and runs them through the existing `analyzeTypeScriptInSvelte` pipeline. A stderr warning fires once on install so opting in is visible at runtime.

ESLint's own reads still go through `fs`, so the parser receives the original Svelte source on every `parseForESLint` call. Only TypeScript sees the shim.

The hook is documented under an Experimental section in the README and ships as a minor bump in the changeset.

## Effect on existing rules

- `services.getTypeAtLocation(node)` — unchanged; the parser still restores node positions to the Svelte source.
- Raw TS diagnostics (`program.getSemanticDiagnostics()` and friends) — also unchanged. Their positions already index into the virtual shim today, because TypeScript only ever sees the shim either way. The hook is a no-op for these.
- `import './Other.svelte'` from a sibling file — newly resolves to real virtual TypeScript instead of an opaque `declare module '*.svelte'`, so type-aware rules report real cross-file types instead of `any`.

## Verification

The public benchmark at [mcous/eslint-svelte-ts-perf](https://github.com/mcous/eslint-svelte-ts-perf) exercises exactly this path on 1001 identical `<script lang=\"ts\">` components.

```sh
git clone https://github.com/mcous/eslint-svelte-ts-perf
cd eslint-svelte-ts-perf
pnpm install

# Baseline: projectService:true, no hook.
time pnpm lint:svelte:slow

> pnpm lint:svelte:slow  51.85s user 2.86s system 108% cpu 50.304 total

# With the hook.
pnpm i -D https://pkg.pr.new/svelte-eslint-parser@d0a5ac3
time SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 pnpm lint:svelte:slow

> SVELTE_ESLINT_PARSER_TS_SYS_HOOK=1 pnpm lint:svelte:slow  6.47s user 1.11s system 116% cpu 6.528 total
```

Expected on a MacBook-class machine: **~50s → ~6s** on a warm run with identical lint output (2002 `no-console` errors). No `.svelte-eslint-parser/` directory or generated tsconfig is created.
