### PR TITLE
WIP (alpha): emit component default export in virtual code for importer prop types

### DIFF
--- a/.changeset/virtual-component-default-export.md
+++ b/.changeset/virtual-component-default-export.md
@@ -1,0 +1,13 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Emit a synthetic component `export default` in the virtual TypeScript so that
+files importing a `.svelte` component can resolve its prop types via
+`import('svelte').ComponentProps<typeof Component>` (e.g. `<Foo value={x} />`).
+
+This is an experimental, alpha-stage feature implemented by Claude Code. Only the
+runes `$props()` type annotation is recognized for now; legacy `export let`,
+`$$Props`, generics, events and slots are handled in follow-up work. It currently
+only takes effect together with the experimental `ts.sys.readFile` hook
+(`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`).

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -152,6 +152,25 @@ export function analyzeTypeScriptInSvelte(
 
   ctx.appendOriginalToEnd();
 
+  // Emit a synthetic `export default` typed as a Svelte component so that other
+  // modules importing this `.svelte` file can resolve its prop types via
+  // `import('svelte').ComponentProps<typeof Component>`. The export is removed
+  // again during the restore pass, so the linted file's AST and scope are
+  // unaffected; it only matters for the virtual file consumed by the TS program
+  // (through the `ts.sys.readFile` hook) when this component is imported.
+  //
+  // It is emitted last, after every original statement (including top-level
+  // snippets) has been consumed, so it always lands as a standalone top-level
+  // statement at end of file.
+  //
+  // NOTE: This is an experimental, alpha-stage feature.
+  appendComponentDefaultExport(
+    result,
+    code.script + code.render + code.rootScope,
+    ctx,
+    context.svelteParseContext,
+  );
+
   return ctx;
 }
 /**
@@ -401,6 +420,109 @@ function analyzeDollarDollarVariables(
       return true;
     });
   }
+}
+
+/**
+ * Append a synthetic component `export default` to the virtual code.
+ *
+ * Files that import a `.svelte` component (e.g. `<Foo value={x} />`) type-check
+ * its props through `import('svelte').ComponentProps<typeof Foo>`. For that to
+ * resolve, the imported component's virtual code must expose a default export
+ * typed as a Svelte component. The original virtual code only exported the
+ * synthetic render function, so `typeof Foo` was `any` and every prop collapsed
+ * to `any`.
+ *
+ * Emitting `export default null as unknown as import('svelte').Component<Props>`
+ * fixes that. `Props` is the user's `$props()` type annotation when it can be
+ * recovered, otherwise a permissive fallback that matches the previous (`any`)
+ * behavior. The statement is removed again in the restore pass so the linted
+ * file itself is unaffected.
+ *
+ * NOTE: Experimental, alpha-stage. Currently only the runes `$props()` type
+ * annotation is recognized; legacy `export let`, `$$Props`, generics, events and
+ * slots are handled in follow-up work.
+ */
+function appendComponentDefaultExport(
+  result: TSESParseForESLintResult,
+  source: string,
+  ctx: VirtualTypeScriptContext,
+  svelteParseContext: SvelteParseContext,
+) {
+  // Don't clash with a user-authored `export default`.
+  if (hasDefaultExport(result.ast)) {
+    return;
+  }
+
+  const propsType =
+    getRunesPropsTypeText(result, source, svelteParseContext) ??
+    "Record<string, any>";
+
+  ctx.appendVirtualScript(
+    `export default null as unknown as import('svelte').Component<${propsType}>;`,
+  );
+  ctx.restoreContext.addRestoreStatementProcess((node, restoreResult) => {
+    if (node.type !== "ExportDefaultDeclaration") {
+      return false;
+    }
+    const program = restoreResult.ast;
+    program.body.splice(program.body.indexOf(node), 1);
+
+    const scopeManager =
+      restoreResult.scopeManager as eslint.Scope.ScopeManager;
+    removeAllScopeAndVariableAndReference(node, {
+      visitorKeys: restoreResult.visitorKeys,
+      scopeManager,
+    });
+
+    return true;
+  });
+}
+
+function hasDefaultExport(ast: TSESParseForESLintResult["ast"]): boolean {
+  return ast.body.some((node) => node.type === "ExportDefaultDeclaration");
+}
+
+/**
+ * Recover the props type text from a runes-mode `$props()` declaration with an
+ * explicit type annotation, e.g. `let { value }: { value: string } = $props()`
+ * returns `{ value: string }`. Returns `null` when there is no annotated
+ * `$props()` call (including legacy mode), so the caller can fall back.
+ */
+function getRunesPropsTypeText(
+  result: TSESParseForESLintResult,
+  source: string,
+  svelteParseContext: SvelteParseContext,
+): string | null {
+  // In non-runes mode `$props()` is not a rune, so skip.
+  if (svelteParseContext.runes === false) {
+    return null;
+  }
+  const propsReferences = result.scopeManager.globalScope!.through.filter(
+    (reference) => reference.identifier.name === "$props",
+  );
+  if (!propsReferences.length) {
+    return null;
+  }
+  setParent(result);
+  for (const reference of propsReferences) {
+    const id = reference.identifier as TSESTree.Identifier;
+    const call = id.parent;
+    if (
+      call?.type !== "CallExpression" ||
+      call.callee !== id ||
+      call.parent?.type !== "VariableDeclarator" ||
+      call.parent.init !== call
+    ) {
+      continue;
+    }
+    const typeAnnotation = call.parent.id.typeAnnotation;
+    if (!typeAnnotation) {
+      continue;
+    }
+    const typeNode = typeAnnotation.typeAnnotation;
+    return source.slice(typeNode.range[0], typeNode.range[1]);
+  }
+  return null;
 }
 
 /** Append dummy export */

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -2,6 +2,8 @@ import assert from "assert";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { createRequire } from "module";
+import ts from "typescript";
 import { normalizeParserOptions } from "../../src/parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "../../src/parser/svelte-to-virtual-ts.js";
 import {
@@ -160,5 +162,149 @@ describe("ts.sys.readFile hook wiring", () => {
 
       assert.strictEqual(sys.readFile(filePath), TS_SCRIPT);
     });
+  });
+});
+
+describe("synthetic component default export", () => {
+  function translate(source: string): string {
+    let result: string | null = null;
+    withTempSvelteFile(source, (filePath) => {
+      result = svelteToVirtualTypeScript(
+        filePath,
+        source,
+        makeParserOptions(filePath),
+      );
+    });
+    assert.notStrictEqual(result, null, "expected non-null translation");
+    return result!;
+  }
+
+  it("recovers the props type from an annotated `$props()` declaration", () => {
+    const code = translate(`<script lang="ts">
+  let { value, count = 0 }: { value: string; count?: number } = $props();
+</script>
+<p>{value}{count}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\{ value: string; count\?: number \}>;/,
+    );
+  });
+
+  it("references a named props interface as-is", () => {
+    const code = translate(`<script lang="ts">
+  interface Props { a: number; b?: string }
+  let props: Props = $props();
+</script>
+<p>{props.a}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<Props>;/,
+    );
+  });
+
+  it("falls back to a permissive props type when none can be recovered", () => {
+    const code = translate(`<script lang="ts">
+  let value = 1;
+</script>
+<p>{value}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<Record<string, any>>;/,
+    );
+  });
+
+  it("does not emit a default export when the user already has one", () => {
+    const code = translate(`<script lang="ts" context="module">
+  export default 42;
+</script>`);
+    assert.doesNotMatch(code, /import\('svelte'\)\.Component</);
+  });
+});
+
+describe("imported component prop types (end-to-end type check)", () => {
+  const require2 = createRequire(import.meta.url);
+  const svelteTypesPath = path.join(
+    path.dirname(require2.resolve("svelte/package.json")),
+    "types/index.d.ts",
+  );
+
+  /**
+   * Type-checks a consumer `.ts` against the virtual code produced for a
+   * `.svelte` component and returns the TypeScript diagnostics. The consumer
+   * resolves the component's props through `ComponentProps<typeof Foo>`, exactly
+   * like the parser's generated template code does.
+   */
+  function typeCheckConsumer(
+    componentSource: string,
+    consumerBody: string,
+  ): ts.Diagnostic[] {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "component-export-"));
+    try {
+      const componentVirtual = svelteToVirtualTypeScript(
+        path.join(dir, "Foo.svelte"),
+        componentSource,
+        makeParserOptions(path.join(dir, "Foo.svelte")),
+      );
+      assert.notStrictEqual(componentVirtual, null);
+      fs.writeFileSync(path.join(dir, "Foo.ts"), componentVirtual!, "utf-8");
+      fs.writeFileSync(
+        path.join(dir, "Bar.ts"),
+        `import Foo from "./Foo";\n${consumerBody}\n`,
+        "utf-8",
+      );
+
+      const program = ts.createProgram(
+        [path.join(dir, "Foo.ts"), path.join(dir, "Bar.ts")],
+        {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          module: ts.ModuleKind.ESNext,
+          moduleResolution: ts.ModuleResolutionKind.Bundler,
+          types: [],
+          baseUrl: dir,
+          paths: { svelte: [svelteTypesPath] },
+        },
+      );
+      return [
+        ...program.getSemanticDiagnostics(),
+        ...program.getSyntacticDiagnostics(),
+      ];
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  const COMPONENT = `<script lang="ts">
+  let { value, count = 0 }: { value: string; count?: number } = $props();
+</script>
+<p>{value}{count}</p>`;
+
+  it("resolves a prop to its declared type for importers", () => {
+    const diagnostics = typeCheckConsumer(
+      COMPONENT,
+      `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123;`,
+    );
+    // `value` is `string`, so assigning a number must be a type error.
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("accepts a correctly typed prop value from importers", () => {
+    const diagnostics = typeCheckConsumer(
+      COMPONENT,
+      `const value: import("svelte").ComponentProps<typeof Foo>["value"] = "hello";\nconst count: import("svelte").ComponentProps<typeof Foo>["count"] = 5;\nvoid value; void count;`,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      [],
+      `expected no diagnostics, got: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+        .join("; ")}`,
+    );
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> This PR is an **alpha-stage** implementation **authored by Claude Code** (AI). It is published as a draft for early review/discussion only. Behavior and API may change or be dropped entirely. It has not been hand-reviewed for production.

## Problem

When a `.svelte` file imports another `.svelte` component (`import Foo from './Foo.svelte'`) and uses it (`<Foo value={x} />`), the parser already type-checks the props through `import('svelte').ComponentProps<typeof Foo>` in the generated virtual code:

```ts
(x) as ('value' extends infer PROP
  ? (PROP extends keyof import('svelte').ComponentProps<typeof Foo>
      ? import('svelte').ComponentProps<typeof Foo>[PROP] : never) : never);
```

But the **producer** side (`Foo.svelte`'s virtual code) only exported the synthetic render function and the module marker namespace — there was **no default export**. So `typeof Foo` resolved to `any`, `ComponentProps<typeof Foo>` collapsed to `any`, and every prop became `any`.

`svelte2tsx` solves this by emitting a typed component default export, but that path isn't available to the ESLint parser's range-preserving virtual code. This PR reproduces an equivalent export ourselves.

## Approach

Append a synthetic default export to the virtual code, typed with Svelte 5's public `Component` type (no `svelte2tsx` shim dependency):

```ts
export default null as unknown as import('svelte').Component<{ value: string; count?: number }>;
```

- `Props` is recovered from the runes `$props()` **type annotation** (`let { ... }: T = $props()` → `T`; named interface refs are passed through as-is). When it can't be recovered, it falls back to `Record<string, any>` — identical to today's permissive `any` behavior, so no regression.
- The statement is **removed again in the restore pass** (same mechanism as the existing dummy export / render function), so the **linted file's own AST and scopeManager are byte-for-byte unchanged**. The existing before/after invariance test suite (80 TS fixtures) enforces this.
- Emitted at end of file, after all original statements (incl. top-level snippets) are consumed, so it's always a clean standalone top-level statement.
- Skipped when the user already authored an `export default`.

It only takes effect together with the experimental `ts.sys.readFile` hook (`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`), which is what lets the TS program read a `.svelte` import as virtual TS.

## Verified

- Full suite green (`8664 passing`), incl. the AST/scope invariance suite proving restore is byte-perfect.
- New unit tests for the recovered/fallback/skip cases.
- New **end-to-end `tsc` test**: a consumer resolving `ComponentProps<typeof Foo>['value']` gets `string` (assigning a `number` errors `TS2322`); correctly typed values produce zero diagnostics.

## Phasing (separate follow-up PRs)

This is **PR 1 of several**, intentionally kept small for review:

- **PR 1 (this):** core mechanism + runes `$props()` type-annotation recovery
- PR 2: legacy `export let` → synthesized props type
- PR 3: `$$Props` interface/type
- PR 4: inference for un-annotated `$props()` destructuring
- PR 5: generics (`<script generics="...">`)
- PR 6: events / slots / bindings (`SvelteComponentTyped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)