### PR TITLE
WIP (alpha): synthesize legacy `export let` prop types in virtual code

### DIFF
--- a/.changeset/virtual-component-export-legacy.md
+++ b/.changeset/virtual-component-export-legacy.md
@@ -1,0 +1,15 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Synthesize the component prop types from legacy `export let` declarations in the
+virtual TypeScript, so importers of a legacy `.svelte` component resolve its
+props via `import('svelte').ComponentProps<typeof Component>`. A default value
+makes the prop optional and an explicit annotation is used as-is, mirroring
+svelte2tsx (e.g. `export let value: string; export let count = 0;` becomes
+`Component<{ value: string; count?: typeof count }>`).
+
+This is an experimental, alpha-stage feature implemented by Claude Code, and a
+follow-up to the runes `$props()` support. It currently only takes effect together
+with the experimental `ts.sys.readFile` hook
+(`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`).

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -438,9 +438,9 @@ function analyzeDollarDollarVariables(
  * behavior. The statement is removed again in the restore pass so the linted
  * file itself is unaffected.
  *
- * NOTE: Experimental, alpha-stage. Currently only the runes `$props()` type
- * annotation is recognized; legacy `export let`, `$$Props`, generics, events and
- * slots are handled in follow-up work.
+ * NOTE: Experimental, alpha-stage. Currently the runes `$props()` type
+ * annotation and legacy `export let` props are recognized; `$$Props`, generics,
+ * events and slots are handled in follow-up work.
  */
 function appendComponentDefaultExport(
   result: TSESParseForESLintResult,
@@ -455,6 +455,7 @@ function appendComponentDefaultExport(
 
   const propsType =
     getRunesPropsTypeText(result, source, svelteParseContext) ??
+    getLegacyExportLetPropsType(result, source, svelteParseContext) ??
     "Record<string, any>";
 
   ctx.appendVirtualScript(
@@ -523,6 +524,55 @@ function getRunesPropsTypeText(
     return source.slice(typeNode.range[0], typeNode.range[1]);
   }
   return null;
+}
+
+/**
+ * Synthesize a props object type from legacy `export let` declarations, e.g.
+ * `export let value: string; export let count = 0;` returns
+ * `{ value: string; count?: typeof count }`. A default value makes the prop
+ * optional and an explicit annotation is used as-is (otherwise the type is
+ * inferred via `typeof`), mirroring svelte2tsx. Returns `null` in runes mode or
+ * when there are no `export let` props.
+ */
+function getLegacyExportLetPropsType(
+  result: TSESParseForESLintResult,
+  source: string,
+  svelteParseContext: SvelteParseContext,
+): string | null {
+  // `export let` is only a prop declaration in legacy (non-runes) mode.
+  if (svelteParseContext.runes === true) {
+    return null;
+  }
+  const members: string[] = [];
+  for (const node of result.ast.body) {
+    if (
+      node.type !== "ExportNamedDeclaration" ||
+      node.declaration?.type !== "VariableDeclaration" ||
+      node.declaration.kind !== "let"
+    ) {
+      continue;
+    }
+    for (const declarator of node.declaration.declarations) {
+      if (declarator.id.type !== "Identifier") {
+        continue;
+      }
+      const name = declarator.id.name;
+      // A default value (initializer) means the prop can be omitted.
+      const optional = declarator.init != null;
+      const typeAnnotation = declarator.id.typeAnnotation;
+      const typeText = typeAnnotation
+        ? source.slice(
+            typeAnnotation.typeAnnotation.range[0],
+            typeAnnotation.typeAnnotation.range[1],
+          )
+        : `typeof ${name}`;
+      members.push(`${name}${optional ? "?" : ""}: ${typeText}`);
+    }
+  }
+  if (!members.length) {
+    return null;
+  }
+  return `{ ${members.join("; ")} }`;
 }
 
 /** Append dummy export */

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -219,6 +219,29 @@ describe("synthetic component default export", () => {
 </script>`);
     assert.doesNotMatch(code, /import\('svelte'\)\.Component</);
   });
+
+  it("synthesizes props from legacy `export let` declarations", () => {
+    const code = translate(`<script lang="ts">
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\{ value: string; count\?: typeof count \}>;/,
+    );
+  });
+
+  it("marks `export let` props with a default value as optional", () => {
+    const code = translate(`<script lang="ts">
+  export let value: string = "x";
+</script>
+<p>{value}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\{ value\?: string \}>;/,
+    );
+  });
 });
 
 describe("imported component prop types (end-to-end type check)", () => {
@@ -305,6 +328,25 @@ describe("imported component prop types (end-to-end type check)", () => {
       `expected no diagnostics, got: ${diagnostics
         .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
         .join("; ")}`,
+    );
+  });
+
+  it("resolves legacy `export let` props to their declared type for importers", () => {
+    const legacyComponent = `<script lang="ts">
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`;
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123;`,
+    );
+    // `value` is `string`, so assigning a number must be a type error.
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
     );
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> This PR is an **alpha-stage** implementation **authored by Claude Code** (AI), published as a draft for early review only. Behavior/API may change or be dropped.

> [!NOTE]
> **Stacked on #905** (base branch = `feat/virtual-component-default-export`). Review #905 first; this PR's diff shows only the legacy `export let` addition. GitHub will retarget it to `main` once #905 merges.

## What

PR **2 of several** in the "expose component prop types to importers" series. PR #905 added the core mechanism + runes `$props()` recovery. This PR recovers prop types from **legacy `export let`** declarations.

`export let value: string; export let count = 0;` now produces:

```ts
export default null as unknown as import('svelte').Component<{ value: string; count?: typeof count }>;
```

Rules (mirroring `svelte2tsx`):
- **Type** = the explicit annotation when present, otherwise inferred via `typeof <name>`.
- **Optional (`?`)** ⟺ the declaration has a default value (initializer).
- Multiple declarators per statement are handled; non-identifier binding patterns are skipped.
- Only applies in non-runes mode; runes `$props()` recovery still takes priority.

As before, the synthetic export is removed again in the restore pass, so the linted file's own AST/scope are unchanged (the `typeof` value references it introduces are cleaned up too — covered by the existing scope-snapshot suite over legacy fixtures).

## Verified

- Full suite green (`8667 passing`).
- New unit tests: legacy required/optional synthesis.
- New **end-to-end `tsc` test**: a consumer of a legacy `export let` component resolves `value` to `string` (assigning a `number` errors `TS2322`).

## Series

- #905 — core mechanism + runes `$props()` type annotation
- **this** — legacy `export let`
- next: `$$Props` interface/type → un-annotated `$props()` inference → generics → events/slots/bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)