### PR TITLE
WIP (alpha): use legacy `$$Props` interface/type as prop types in virtual code

### DIFF
--- a/.changeset/virtual-component-export-dollar-props.md
+++ b/.changeset/virtual-component-export-dollar-props.md
@@ -1,0 +1,13 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Use a legacy `$$Props` interface or type alias as the component prop types in the
+virtual TypeScript when present, taking priority over `export let` inference (as
+in svelte2tsx). This lets importers of a `.svelte` component that types its props
+with `$$Props` resolve them via `import('svelte').ComponentProps<typeof Component>`.
+
+This is an experimental, alpha-stage feature implemented by Claude Code, and a
+follow-up to the runes `$props()` and legacy `export let` support. It currently
+only takes effect together with the experimental `ts.sys.readFile` hook
+(`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`).

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -439,8 +439,8 @@ function analyzeDollarDollarVariables(
  * file itself is unaffected.
  *
  * NOTE: Experimental, alpha-stage. Currently the runes `$props()` type
- * annotation and legacy `export let` props are recognized; `$$Props`, generics,
- * events and slots are handled in follow-up work.
+ * annotation, a legacy `$$Props` interface/type and legacy `export let` props are
+ * recognized; generics, events and slots are handled in follow-up work.
  */
 function appendComponentDefaultExport(
   result: TSESParseForESLintResult,
@@ -455,6 +455,7 @@ function appendComponentDefaultExport(
 
   const propsType =
     getRunesPropsTypeText(result, source, svelteParseContext) ??
+    getDollarDollarPropsType(result, svelteParseContext) ??
     getLegacyExportLetPropsType(result, source, svelteParseContext) ??
     "Record<string, any>";
 
@@ -524,6 +525,29 @@ function getRunesPropsTypeText(
     return source.slice(typeNode.range[0], typeNode.range[1]);
   }
   return null;
+}
+
+/**
+ * Use a legacy `$$Props` interface or type alias as the props type when present.
+ * Svelte treats `$$Props` as the authoritative prop typing, so it takes priority
+ * over `export let` inference. The declaration stays in the virtual code, so it
+ * can be referenced by name. Returns `null` in runes mode or when no `$$Props`
+ * declaration exists.
+ */
+function getDollarDollarPropsType(
+  result: TSESParseForESLintResult,
+  svelteParseContext: SvelteParseContext,
+): string | null {
+  if (svelteParseContext.runes === true) {
+    return null;
+  }
+  const hasDollarProps = result.ast.body.some(
+    (node) =>
+      (node.type === "TSInterfaceDeclaration" ||
+        node.type === "TSTypeAliasDeclaration") &&
+      node.id.name === "$$Props",
+  );
+  return hasDollarProps ? "$$Props" : null;
 }
 
 /**

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -242,6 +242,31 @@ describe("synthetic component default export", () => {
       /export default null as unknown as import\('svelte'\)\.Component<\{ value\?: string \}>;/,
     );
   });
+
+  it("uses a legacy `$$Props` interface, taking priority over `export let`", () => {
+    const code = translate(`<script lang="ts">
+  interface $$Props { value: string; count?: number }
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\$\$Props>;/,
+    );
+  });
+
+  it("uses a legacy `$$Props` type alias", () => {
+    const code = translate(`<script lang="ts">
+  type $$Props = { a: number };
+  export let a: number;
+</script>
+<p>{a}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\$\$Props>;/,
+    );
+  });
 });
 
 describe("imported component prop types (end-to-end type check)", () => {
@@ -342,6 +367,25 @@ describe("imported component prop types (end-to-end type check)", () => {
       `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123;`,
     );
     // `value` is `string`, so assigning a number must be a type error.
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("resolves legacy `$$Props` props to their declared type for importers", () => {
+    const legacyComponent = `<script lang="ts">
+  interface $$Props { value: string; count?: number }
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`;
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123;`,
+    );
     assert.ok(
       diagnostics.some((d) => d.code === 2322),
       `expected TS2322 (number not assignable to string), got: ${diagnostics


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> This PR is an **alpha-stage** implementation **authored by Claude Code** (AI), published as a draft for early review only. Behavior/API may change or be dropped.

> [!NOTE]
> **Stacked on #906** (base branch = `feat/virtual-component-export-legacy`, which is stacked on #905). Review #905 → #906 first; this PR's diff shows only the `$$Props` addition. GitHub retargets it automatically as the parents merge.

## What

PR **3 of several**. When a legacy component declares a `$$Props` interface or type alias, use it as the component prop type, **taking priority over `export let` inference** — matching `svelte2tsx`, which emits `... as $$Props`.

```svelte
<script lang="ts">
  interface $$Props { value: string; count?: number }
  export let value: string;
  export let count = 0;
</script>
```

now produces:

```ts
export default null as unknown as import('svelte').Component<$$Props>;
```

- Recognizes both `interface $$Props {…}` and `type $$Props = …`.
- The declaration already stays in the virtual code, so it's referenced by name.
- Only applies in non-runes mode; runes `$props()` recovery still takes priority.

Priority order is now: runes `$props()` annotation → `$$Props` → `export let` synthesis → permissive fallback.

## Verified

- Full suite green (`8667 passing`).
- New unit tests: `$$Props` interface (priority over `export let`) and type-alias forms.
- New **end-to-end `tsc` test**: a consumer of a `$$Props`-typed component resolves `value` to `string` (assigning a `number` errors `TS2322`).

## Series

- #905 — core mechanism + runes `$props()` type annotation
- #906 — legacy `export let`
- **this** — legacy `$$Props`
- next: un-annotated `$props()` inference → generics → events/slots/bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)