### PR TITLE
WIP (alpha): infer best-effort props type from un-annotated `$props()`

### DIFF
--- a/.changeset/virtual-component-export-infer-props.md
+++ b/.changeset/virtual-component-export-infer-props.md
@@ -1,0 +1,15 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Infer a best-effort props type from an un-annotated runes `$props()`
+destructuring in the virtual TypeScript, e.g. `let { value, count = 0 } =
+$props()` becomes `Component<{ value: any; count?: any }>`. This captures the
+prop names and which are required (a default value makes a prop optional), so
+importers catch missing required props and unknown props even though the value
+types stay `any` (annotate `$props()` for precise types). Patterns with a rest
+element or computed keys fall back to a permissive type.
+
+This is an experimental, alpha-stage feature implemented by Claude Code. It
+currently only takes effect together with the experimental `ts.sys.readFile` hook
+(`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`).

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -485,10 +485,18 @@ function hasDefaultExport(ast: TSESParseForESLintResult["ast"]): boolean {
 }
 
 /**
- * Recover the props type text from a runes-mode `$props()` declaration with an
- * explicit type annotation, e.g. `let { value }: { value: string } = $props()`
- * returns `{ value: string }`. Returns `null` when there is no annotated
- * `$props()` call (including legacy mode), so the caller can fall back.
+ * Recover the props type text from a runes-mode `$props()` declaration.
+ *
+ * With an explicit annotation it is used as-is, e.g.
+ * `let { value }: { value: string } = $props()` returns `{ value: string }`.
+ * Without one, a best-effort object type is inferred from the destructuring
+ * pattern: each prop becomes `any`, and a default value makes it optional, e.g.
+ * `let { value, count = 0 } = $props()` returns `{ value: any; count?: any }`.
+ * This captures the prop names and which are required, even though the value
+ * types stay `any` (annotate the props for precise types).
+ *
+ * Returns `null` when there is no usable `$props()` call (including legacy mode),
+ * so the caller can fall back.
  */
 function getRunesPropsTypeText(
   result: TSESParseForESLintResult,
@@ -517,14 +525,48 @@ function getRunesPropsTypeText(
     ) {
       continue;
     }
-    const typeAnnotation = call.parent.id.typeAnnotation;
-    if (!typeAnnotation) {
-      continue;
+    const declId = call.parent.id;
+    const typeAnnotation = declId.typeAnnotation;
+    if (typeAnnotation) {
+      const typeNode = typeAnnotation.typeAnnotation;
+      return source.slice(typeNode.range[0], typeNode.range[1]);
     }
-    const typeNode = typeAnnotation.typeAnnotation;
-    return source.slice(typeNode.range[0], typeNode.range[1]);
+    if (declId.type === "ObjectPattern") {
+      const inferred = inferPropsTypeFromObjectPattern(declId);
+      if (inferred != null) {
+        return inferred;
+      }
+    }
   }
   return null;
+}
+
+/**
+ * Build a best-effort props object type from a `$props()` destructuring pattern,
+ * e.g. `{ value, count = 0 }` becomes `{ value: any; count?: any }`. A default
+ * value makes the prop optional. Returns `null` for patterns whose full shape
+ * can't be enumerated (a rest element, or computed/non-identifier keys), so the
+ * caller can fall back to a permissive type.
+ */
+function inferPropsTypeFromObjectPattern(
+  pattern: TSESTree.ObjectPattern,
+): string | null {
+  const members: string[] = [];
+  for (const prop of pattern.properties) {
+    if (
+      prop.type !== "Property" ||
+      prop.computed ||
+      prop.key.type !== "Identifier"
+    ) {
+      // A rest element or computed/non-identifier key means we can't enumerate
+      // the complete prop set.
+      return null;
+    }
+    // A default value (`AssignmentPattern`) means the prop can be omitted.
+    const optional = prop.value.type === "AssignmentPattern";
+    members.push(`${prop.key.name}${optional ? "?" : ""}: any`);
+  }
+  return `{ ${members.join("; ")} }`;
 }
 
 /**

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -267,6 +267,28 @@ describe("synthetic component default export", () => {
       /export default null as unknown as import\('svelte'\)\.Component<\$\$Props>;/,
     );
   });
+
+  it("infers prop names and optionality from an un-annotated `$props()`", () => {
+    const code = translate(`<script lang="ts">
+  let { value, count = 0 } = $props();
+</script>
+<p>{value}{count}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\{ value: any; count\?: any \}>;/,
+    );
+  });
+
+  it("falls back when an un-annotated `$props()` has a rest element", () => {
+    const code = translate(`<script lang="ts">
+  let { value, ...rest } = $props();
+</script>
+<p>{value}</p>`);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<Record<string, any>>;/,
+    );
+  });
 });
 
 describe("imported component prop types (end-to-end type check)", () => {
@@ -391,6 +413,23 @@ describe("imported component prop types (end-to-end type check)", () => {
       `expected TS2322 (number not assignable to string), got: ${diagnostics
         .map((d) => d.code)
         .join(", ")}`,
+    );
+  });
+
+  it("enforces required props inferred from an un-annotated `$props()`", () => {
+    const inferredComponent = `<script lang="ts">
+  let { value, count = 0 } = $props();
+</script>
+<p>{value}{count}</p>`;
+    // `value` is required (no default), `count` optional. Omitting `value`
+    // must be an error even though the prop types are `any`.
+    const diagnostics = typeCheckConsumer(
+      inferredComponent,
+      `const props: import("svelte").ComponentProps<typeof Foo> = {}; void props;`,
+    );
+    assert.ok(
+      diagnostics.length > 0,
+      "expected a missing-required-prop error for the empty props object",
     );
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> Alpha-stage implementation **authored by Claude Code** (AI), published as a draft for early review only. Behavior/API may change or be dropped.

> [!NOTE]
> **Stacked on #907** (→ #906 → #905). Review the parents first; this PR's diff shows only the inference addition.

## What

PR **4 of several**. When a runes `$props()` destructuring has **no type annotation**, infer a best-effort object type from the pattern instead of falling back to the fully-permissive `Record<string, any>`:

```svelte
<script lang="ts">
  let { value, count = 0 } = $props();
</script>
```

now produces:

```ts
export default null as unknown as import('svelte').Component<{ value: any; count?: any }>;
```

- Each prop is typed `any`; a **default value makes it optional** (`count?`), otherwise it's **required** (`value`).
- This mirrors svelte2tsx's structure (it infers `{ value: any; count?: number }`). We can't recover the value types statically — the parser's `$props` shim is `<T>(): T`, so an un-annotated call yields `unknown`/`any` and `typeof`-based recovery collapses to `any` (verified). So value types stay `any`; **annotate `$props()` for precise types**.
- Still useful over the old fallback: importers now catch **missing required props** and **unknown props**.
- Patterns with a **rest element** or **computed/non-identifier keys** can't be fully enumerated → fall back to the permissive type.
- An explicit annotation still takes priority (PR #905).

## Verified

- Full suite green (`8670 passing`).
- New unit tests: inferred required/optional shape; rest-element fallback.
- New **end-to-end `tsc` test**: omitting a required inferred prop (`value`) errors for importers.

## Series

- #905 runes `$props()` annotation · #906 `export let` · #907 `$$Props` · **this** un-annotated `$props()` inference
- next: generics → events/slots/bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)