### PR TITLE
WIP (alpha): cover generic component prop types for importers

### DIFF
--- a/.changeset/virtual-component-export-generics.md
+++ b/.changeset/virtual-component-export-generics.md
@@ -1,0 +1,14 @@
+---
+"svelte-eslint-parser": patch
+---
+
+Confirm that generic components (`<script lang="ts" generics="...">`) expose their
+props to importers through `import('svelte').ComponentProps<typeof Component>`.
+The parser already declares the generic type parameters in the virtual code
+(`type T = unknown`, or the constraint when one is given), so the recovered props
+annotation referencing them stays valid; type parameters resolve to their
+constraint (or `unknown`) on the importer side. This change only adds test
+coverage — no behavior change.
+
+Part of the experimental, alpha-stage component prop-type series implemented by
+Claude Code.

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -289,6 +289,20 @@ describe("synthetic component default export", () => {
       /export default null as unknown as import\('svelte'\)\.Component<Record<string, any>>;/,
     );
   });
+
+  it("references `generics` type parameters in the props type", () => {
+    // The parser already declares the generic params (`type T = unknown`), so
+    // the recovered annotation referencing them stays valid.
+    const code = translate(`<script lang="ts" generics="T">
+  let { items, selected }: { items: T[]; selected: T } = $props();
+</script>
+<p>{selected}</p>`);
+    assert.match(code, /type T = unknown;/);
+    assert.match(
+      code,
+      /export default null as unknown as import\('svelte'\)\.Component<\{ items: T\[\]; selected: T \}>;/,
+    );
+  });
 });
 
 describe("imported component prop types (end-to-end type check)", () => {
@@ -430,6 +444,43 @@ describe("imported component prop types (end-to-end type check)", () => {
     assert.ok(
       diagnostics.length > 0,
       "expected a missing-required-prop error for the empty props object",
+    );
+  });
+
+  it("resolves generic component props (type params as their constraint) for importers", () => {
+    // `generics="T extends string"`, so `v` resolves to `string`.
+    const genericComponent = `<script lang="ts" generics="T extends string">
+  let { v }: { v: T } = $props();
+</script>
+<p>{v}</p>`;
+    const diagnostics = typeCheckConsumer(
+      genericComponent,
+      `const v: import("svelte").ComponentProps<typeof Foo>["v"] = 123;`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("accepts valid props on an unconstrained generic component", () => {
+    const genericComponent = `<script lang="ts" generics="T">
+  let { items, selected }: { items: T[]; selected: T } = $props();
+</script>
+<p>{selected}</p>`;
+    // `T` resolves to `unknown`, so a concrete props object is accepted.
+    const diagnostics = typeCheckConsumer(
+      genericComponent,
+      `const props: import("svelte").ComponentProps<typeof Foo> = { items: [1, 2], selected: 2 }; void props;`,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      [],
+      `expected no diagnostics, got: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+        .join("; ")}`,
     );
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> Alpha-stage work **authored by Claude Code** (AI), published as a draft for early review only.

> [!NOTE]
> **Stacked on #908** (→ #907 → #906 → #905). Review the parents first.

## What

PR **5 of several** — **generics**. Pleasant surprise: this needed **no source change**. Generic components already expose their props to importers, because:

1. The parser already lowers `generics="T"` into the virtual code as `type T = unknown` (or `type T = <constraint>` when one is given).
2. The recovered `$props()` annotation (PR #905) references those params verbatim.

So for:

```svelte
<script lang="ts" generics="T extends string">
  let { v }: { v: T } = $props();
</script>
```

the emitted export is `Component<{ v: T }>` with `type T = string` in scope, and importers see `ComponentProps<typeof Foo>['v'] === string`. For unconstrained `generics="T"`, the param resolves to `unknown` (so concrete props are accepted but cross-prop generic relationships aren't enforced — an acceptable approximation vs svelte2tsx's full generic machinery).

This PR adds **test coverage only** to lock the behavior in:
- Unit: the props annotation references `generics` params and `type T = unknown` is present.
- **End-to-end `tsc`**: constrained `T extends string` resolves `v` to `string` (number errors `TS2322`); unconstrained `T` accepts a concrete props object with no diagnostics.

## Verified

- Full suite green (`26` in this file's suites; full run green).

## Series

- #905 runes `$props()` · #906 `export let` · #907 `$$Props` · #908 un-annotated inference · **this** generics
- next (final): events / slots / bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)