### PR TITLE
WIP (alpha): expose component events/slots, emit value+type default export

### DIFF
--- a/.changeset/virtual-component-export-events-slots.md
+++ b/.changeset/virtual-component-export-events-slots.md
@@ -1,0 +1,27 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Expose component events and slots to importers, and emit the synthetic default
+export as a value/type pair so it can be used both as a value and as a type. This
+fixes legacy `on:` event consumers, where the parser references the component via
+`import('svelte').ComponentEvents<Foo>` (using `Foo` as a *type*) — previously the
+value-only `export default` made that fail with "'Foo' refers to a value, but is
+being used as a type".
+
+The export is now:
+
+```ts
+declare const $c: import('svelte').SvelteComponent<Props, Events, Slots>;
+type $c = import('svelte').SvelteComponent<Props, Events, Slots>;
+export { $c as default };
+```
+
+`Events`/`Slots` come from legacy `$$Events`/`$$Slots` declarations when present,
+otherwise stay permissive so `on:`/slots don't get spurious errors. Props
+resolution via `ComponentProps<typeof Foo>` is unchanged.
+
+This is an experimental, alpha-stage feature implemented by Claude Code, and the
+final part of the component prop/event/slot type series. It currently only takes
+effect together with the experimental `ts.sys.readFile` hook
+(`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`).

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -423,24 +423,31 @@ function analyzeDollarDollarVariables(
 }
 
 /**
- * Append a synthetic component `export default` to the virtual code.
+ * Append a synthetic component default export to the virtual code.
  *
- * Files that import a `.svelte` component (e.g. `<Foo value={x} />`) type-check
- * its props through `import('svelte').ComponentProps<typeof Foo>`. For that to
- * resolve, the imported component's virtual code must expose a default export
- * typed as a Svelte component. The original virtual code only exported the
- * synthetic render function, so `typeof Foo` was `any` and every prop collapsed
- * to `any`.
+ * Files that import a `.svelte` component type-check it through Svelte's helper
+ * types: props via `import('svelte').ComponentProps<typeof Foo>` and legacy
+ * events via `import('svelte').ComponentEvents<Foo>`. The original virtual code
+ * only exported the synthetic render function, so `typeof Foo` was `any` and
+ * every prop collapsed to `any`.
  *
- * Emitting `export default null as unknown as import('svelte').Component<Props>`
- * fixes that. `Props` is the user's `$props()` type annotation when it can be
- * recovered, otherwise a permissive fallback that matches the previous (`any`)
- * behavior. The statement is removed again in the restore pass so the linted
- * file itself is unaffected.
+ * Note the two reference shapes: props use `typeof Foo` (the imported value)
+ * while `ComponentEvents<Foo>` uses `Foo` as a *type*. So the default export must
+ * carry both a value and a type meaning. A single `export default <expr>` only
+ * provides a value (and would make `ComponentEvents<Foo>` fail with "Foo refers
+ * to a value but is used as a type"). Instead emit a value/type pair re-exported
+ * as default:
  *
- * NOTE: Experimental, alpha-stage. Currently the runes `$props()` type
- * annotation, a legacy `$$Props` interface/type and legacy `export let` props are
- * recognized; generics, events and slots are handled in follow-up work.
+ *   declare const $c: import('svelte').SvelteComponent<Props, Events, Slots>;
+ *   type $c = import('svelte').SvelteComponent<Props, Events, Slots>;
+ *   export { $c as default };
+ *
+ * `Props`/`Events`/`Slots` are recovered from the component when possible
+ * (`$props()` annotation, `$$Props`/`$$Events`/`$$Slots`, `export let`), else a
+ * permissive fallback that matches the previous (`any`) behavior. The statements
+ * are removed again in the restore pass so the linted file itself is unaffected.
+ *
+ * NOTE: Experimental, alpha-stage.
  */
 function appendComponentDefaultExport(
   result: TSESParseForESLintResult,
@@ -448,7 +455,7 @@ function appendComponentDefaultExport(
   ctx: VirtualTypeScriptContext,
   svelteParseContext: SvelteParseContext,
 ) {
-  // Don't clash with a user-authored `export default`.
+  // Don't clash with a user-authored default export.
   if (hasDefaultExport(result.ast)) {
     return;
   }
@@ -458,30 +465,97 @@ function appendComponentDefaultExport(
     getDollarDollarPropsType(result, svelteParseContext) ??
     getLegacyExportLetPropsType(result, source, svelteParseContext) ??
     "Record<string, any>";
+  // Legacy `$$Events`/`$$Slots` declarations type events/slots; otherwise stay
+  // permissive so `on:`/slots don't get spurious errors.
+  const eventsType = hasNamedTypeDeclaration(result, "$$Events")
+    ? "$$Events"
+    : "Record<string, any>";
+  const slotsType = hasNamedTypeDeclaration(result, "$$Slots")
+    ? "$$Slots"
+    : "Record<string, any>";
 
+  const name = ctx.generateUniqueId("svelteComponent");
+  const componentType = `import('svelte').SvelteComponent<${propsType}, ${eventsType}, ${slotsType}>`;
   ctx.appendVirtualScript(
-    `export default null as unknown as import('svelte').Component<${propsType}>;`,
+    `declare const ${name}: ${componentType};type ${name} = ${componentType};export { ${name} as default };`,
   );
+
+  // Re-export specifier: `export { <name> as default }`.
   ctx.restoreContext.addRestoreStatementProcess((node, restoreResult) => {
-    if (node.type !== "ExportDefaultDeclaration") {
+    if (
+      node.type !== "ExportNamedDeclaration" ||
+      node.declaration != null ||
+      node.specifiers.length !== 1 ||
+      node.specifiers[0].local.type !== "Identifier" ||
+      node.specifiers[0].local.name !== name
+    ) {
       return false;
     }
-    const program = restoreResult.ast;
-    program.body.splice(program.body.indexOf(node), 1);
-
-    const scopeManager =
-      restoreResult.scopeManager as eslint.Scope.ScopeManager;
-    removeAllScopeAndVariableAndReference(node, {
-      visitorKeys: restoreResult.visitorKeys,
-      scopeManager,
-    });
-
+    removeSyntheticStatement(node, restoreResult);
+    return true;
+  });
+  // `declare const <name>: ...`.
+  ctx.restoreContext.addRestoreStatementProcess((node, restoreResult) => {
+    if (
+      node.type !== "VariableDeclaration" ||
+      node.declarations[0]?.id.type !== "Identifier" ||
+      node.declarations[0].id.name !== name
+    ) {
+      return false;
+    }
+    removeSyntheticStatement(node, restoreResult);
+    return true;
+  });
+  // `type <name> = ...`.
+  ctx.restoreContext.addRestoreStatementProcess((node, restoreResult) => {
+    if (node.type !== "TSTypeAliasDeclaration" || node.id.name !== name) {
+      return false;
+    }
+    removeSyntheticStatement(node, restoreResult);
     return true;
   });
 }
 
+/** Splice a synthetic statement out of the AST and clean up its scope. */
+function removeSyntheticStatement(
+  node: TSESTree.Node,
+  restoreResult: TSESParseForESLintResult,
+): void {
+  const program = restoreResult.ast;
+  program.body.splice(program.body.indexOf(node as never), 1);
+  removeAllScopeAndVariableAndReference(node, {
+    visitorKeys: restoreResult.visitorKeys,
+    scopeManager: restoreResult.scopeManager as eslint.Scope.ScopeManager,
+  });
+}
+
 function hasDefaultExport(ast: TSESParseForESLintResult["ast"]): boolean {
-  return ast.body.some((node) => node.type === "ExportDefaultDeclaration");
+  return ast.body.some((node) => {
+    if (node.type === "ExportDefaultDeclaration") {
+      return true;
+    }
+    if (node.type === "ExportNamedDeclaration") {
+      return node.specifiers.some(
+        (specifier) =>
+          specifier.exported.type === "Identifier" &&
+          specifier.exported.name === "default",
+      );
+    }
+    return false;
+  });
+}
+
+/** Whether a top-level `interface <name>` or `type <name>` is declared. */
+function hasNamedTypeDeclaration(
+  result: TSESParseForESLintResult,
+  name: string,
+): boolean {
+  return result.ast.body.some(
+    (node) =>
+      (node.type === "TSInterfaceDeclaration" ||
+        node.type === "TSTypeAliasDeclaration") &&
+      node.id.name === name,
+  );
 }
 
 /**
@@ -583,13 +657,7 @@ function getDollarDollarPropsType(
   if (svelteParseContext.runes === true) {
     return null;
   }
-  const hasDollarProps = result.ast.body.some(
-    (node) =>
-      (node.type === "TSInterfaceDeclaration" ||
-        node.type === "TSTypeAliasDeclaration") &&
-      node.id.name === "$$Props",
-  );
-  return hasDollarProps ? "$$Props" : null;
+  return hasNamedTypeDeclaration(result, "$$Props") ? "$$Props" : null;
 }
 
 /**

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -186,7 +186,7 @@ describe("synthetic component default export", () => {
 <p>{value}{count}</p>`);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<\{ value: string; count\?: number \}>;/,
+      /import\('svelte'\)\.SvelteComponent<\{ value: string; count\?: number \}, /,
     );
   });
 
@@ -196,10 +196,7 @@ describe("synthetic component default export", () => {
   let props: Props = $props();
 </script>
 <p>{props.a}</p>`);
-    assert.match(
-      code,
-      /export default null as unknown as import\('svelte'\)\.Component<Props>;/,
-    );
+    assert.match(code, /import\('svelte'\)\.SvelteComponent<Props, /);
   });
 
   it("falls back to a permissive props type when none can be recovered", () => {
@@ -209,7 +206,7 @@ describe("synthetic component default export", () => {
 <p>{value}</p>`);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<Record<string, any>>;/,
+      /import\('svelte'\)\.SvelteComponent<Record<string, any>, /,
     );
   });
 
@@ -217,7 +214,8 @@ describe("synthetic component default export", () => {
     const code = translate(`<script lang="ts" context="module">
   export default 42;
 </script>`);
-    assert.doesNotMatch(code, /import\('svelte'\)\.Component</);
+    assert.doesNotMatch(code, /import\('svelte'\)\.SvelteComponent</);
+    assert.match(code, /export default 42/);
   });
 
   it("synthesizes props from legacy `export let` declarations", () => {
@@ -228,7 +226,7 @@ describe("synthetic component default export", () => {
 <p>{value}{count}</p>`);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<\{ value: string; count\?: typeof count \}>;/,
+      /import\('svelte'\)\.SvelteComponent<\{ value: string; count\?: typeof count \}, /,
     );
   });
 
@@ -239,7 +237,7 @@ describe("synthetic component default export", () => {
 <p>{value}</p>`);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<\{ value\?: string \}>;/,
+      /import\('svelte'\)\.SvelteComponent<\{ value\?: string \}, /,
     );
   });
 
@@ -250,10 +248,7 @@ describe("synthetic component default export", () => {
   export let count = 0;
 </script>
 <p>{value}{count}</p>`);
-    assert.match(
-      code,
-      /export default null as unknown as import\('svelte'\)\.Component<\$\$Props>;/,
-    );
+    assert.match(code, /import\('svelte'\)\.SvelteComponent<\$\$Props, /);
   });
 
   it("uses a legacy `$$Props` type alias", () => {
@@ -262,10 +257,7 @@ describe("synthetic component default export", () => {
   export let a: number;
 </script>
 <p>{a}</p>`);
-    assert.match(
-      code,
-      /export default null as unknown as import\('svelte'\)\.Component<\$\$Props>;/,
-    );
+    assert.match(code, /import\('svelte'\)\.SvelteComponent<\$\$Props, /);
   });
 
   it("infers prop names and optionality from an un-annotated `$props()`", () => {
@@ -275,7 +267,7 @@ describe("synthetic component default export", () => {
 <p>{value}{count}</p>`);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<\{ value: any; count\?: any \}>;/,
+      /import\('svelte'\)\.SvelteComponent<\{ value: any; count\?: any \}, /,
     );
   });
 
@@ -286,7 +278,7 @@ describe("synthetic component default export", () => {
 <p>{value}</p>`);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<Record<string, any>>;/,
+      /import\('svelte'\)\.SvelteComponent<Record<string, any>, /,
     );
   });
 
@@ -300,8 +292,34 @@ describe("synthetic component default export", () => {
     assert.match(code, /type T = unknown;/);
     assert.match(
       code,
-      /export default null as unknown as import\('svelte'\)\.Component<\{ items: T\[\]; selected: T \}>;/,
+      /import\('svelte'\)\.SvelteComponent<\{ items: T\[\]; selected: T \}, /,
     );
+  });
+
+  it("wires legacy `$$Events` and `$$Slots` into the component type", () => {
+    const code = translate(`<script lang="ts">
+  interface $$Props { value: string }
+  interface $$Events { foo: CustomEvent<number> }
+  interface $$Slots { default: {} }
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assert.match(
+      code,
+      /import\('svelte'\)\.SvelteComponent<\$\$Props, \$\$Events, \$\$Slots>/,
+    );
+  });
+
+  it("exposes the default export as both a value and a type", () => {
+    // `ComponentProps<typeof Foo>` needs the value, `ComponentEvents<Foo>` needs
+    // the type — so the export must carry both meanings.
+    const code = translate(`<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`);
+    assert.match(code, /declare const (\$_svelteComponent\d+):/);
+    assert.match(code, /type \$_svelteComponent\d+ = /);
+    assert.match(code, /export \{ \$_svelteComponent\d+ as default \};/);
   });
 });
 
@@ -479,6 +497,52 @@ describe("imported component prop types (end-to-end type check)", () => {
       diagnostics.map((d) => d.code),
       [],
       `expected no diagnostics, got: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+        .join("; ")}`,
+    );
+  });
+
+  it("resolves legacy `$$Events` event types for importers", () => {
+    const legacyComponent = `<script lang="ts">
+  interface $$Events { foo: CustomEvent<number> }
+  export let value: string;
+</script>
+<p>{value}</p>`;
+    // `ComponentEvents<Foo>` uses `Foo` as a type. It must resolve (no TS2749)
+    // and carry the declared event detail type.
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `type E = import("svelte").ComponentEvents<Foo>;\nconst bad: E["foo"] = null as unknown as CustomEvent<string>;\nvoid bad;`,
+    );
+    // `foo` is `CustomEvent<number>`, so a `CustomEvent<string>` must error and
+    // crucially `Foo` used as a type must not raise TS2749.
+    assert.ok(
+      !diagnostics.some((d) => d.code === 2749),
+      "expected `Foo` to be usable as a type (no TS2749)",
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 for the wrong event detail type, got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("keeps `Foo` usable as a type even without `$$Events` (no regression)", () => {
+    const legacyComponent = `<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`;
+    // Without `$$Events`, events stay permissive (`any`), but `ComponentEvents<Foo>`
+    // must still resolve rather than failing with "Foo refers to a value".
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `type E = import("svelte").ComponentEvents<Foo>;\nconst e: E["anything"] = 1;\nvoid e;`,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      [],
+      `expected no diagnostics (events permissive, Foo usable as a type), got: ${diagnostics
         .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
         .join("; ")}`,
     );


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> Alpha-stage work **authored by Claude Code** (AI), published as a draft for early review only. Behavior/API may change or be dropped.

> [!NOTE]
> **Stacked on #909** (→ #908 → #907 → #906 → #905). Review the parents first.

## What

PR **6 of 6** (final) — **events / slots**, plus a **regression fix**.

### The regression this fixes

Investigating the consumer side showed the parser references an imported component's **legacy events** via `import('svelte').ComponentEvents<Foo>` — using `Foo` as a **type**. But PRs #905–#909 emitted a value-only `export default <expr>`, so `Foo` had no type meaning and `ComponentEvents<Foo>` failed with:

> TS2749: 'Foo' refers to a value, but is being used as a type here.

(For `bind:` and slots, the consumer generates **no** component-type reference, so those need nothing on the producer side. Runes event props like `onclick` already flow through `ComponentProps`.)

### The fix

Emit the default export as a **value + type pair**, so `Foo` works as both:

```ts
declare const $c: import('svelte').SvelteComponent<Props, Events, Slots>;
type $c = import('svelte').SvelteComponent<Props, Events, Slots>;
export { $c as default };
```

- `typeof Foo` → the value (`SvelteComponent<…>`) → `ComponentProps<typeof Foo>` ✓ (props unchanged from #905–#909)
- `Foo` as a type → `ComponentEvents<Foo>` / `ComponentProps<Foo>` ✓ (no more TS2749)
- `Events`/`Slots` come from legacy `$$Events`/`$$Slots` when declared, else permissive `Record<string, any>` (no spurious `on:`/slot errors).
- All **three** synthetic statements are removed again in the restore pass; the AST/scope-invariance suite (80 fixtures) confirms it's byte-perfect.

This redesigns the emitted form from `Component<Props>` to the `SvelteComponent` value/type pair, so the #905–#909 string-assertion tests are updated here to match (behavior/E2E tests are unchanged).

## Verified

- Full suite green (`8680 passing`), incl. AST/scope invariance.
- New unit tests: `$$Events`/`$$Slots` wired in; export carries both value and type.
- New **end-to-end `tsc` tests**: legacy `$$Events` event detail resolves (`CustomEvent<number>`); `Foo` usable as a type with **no TS2749** even without `$$Events`.

## Series (complete)

- #905 runes `$props()` · #906 `export let` · #907 `$$Props` · #908 un-annotated inference · #909 generics · **this** events/slots + value/type export

🤖 Generated with [Claude Code](https://claude.com/claude-code)