### PR TITLE
WIP (alpha): complete Svelte 5 support (Component value type, literal prop defaults)

### DIFF
--- a/.changeset/virtual-component-export-svelte5.md
+++ b/.changeset/virtual-component-export-svelte5.md
@@ -1,0 +1,18 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Complete Svelte 5 support for the synthetic component export. The exported value
+is now typed as the Svelte 5 `import('svelte').Component<Props>`, so `typeof Foo`
+matches modern usage — importers can `mount(Foo, …)` and pass it to Svelte 5 APIs
+with correct prop checking (the same-named legacy `SvelteComponent` type alias is
+kept so `ComponentEvents<Foo>` still resolves for Svelte 4).
+
+Un-annotated runes `$props()` now also recovers literal default types: `let
+{ value, count = 0, name = "x" } = $props()` becomes
+`Component<{ value: any; count?: number; name?: string }>` (non-literal defaults
+and props without a default stay `any`).
+
+This is an experimental, alpha-stage feature implemented by Claude Code, and only
+takes effect together with the experimental `ts.sys.readFile` hook
+(`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`).

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -438,9 +438,13 @@ function analyzeDollarDollarVariables(
  * to a value but is used as a type"). Instead emit a value/type pair re-exported
  * as default:
  *
- *   declare const $c: import('svelte').SvelteComponent<Props, Events, Slots>;
+ *   declare const $c: import('svelte').Component<Props>;
  *   type $c = import('svelte').SvelteComponent<Props, Events, Slots>;
  *   export { $c as default };
+ *
+ * The value is the Svelte 5 `Component`, so `typeof Foo` matches modern usage
+ * (`mount(Foo)`, `ComponentProps<typeof Foo>`); the same-named legacy
+ * `SvelteComponent` type keeps `ComponentEvents<Foo>` resolving for Svelte 4.
  *
  * `Props`/`Events`/`Slots` are recovered from the component when possible
  * (`$props()` annotation, `$$Props`/`$$Events`/`$$Slots`, `export let`), else a
@@ -475,9 +479,15 @@ function appendComponentDefaultExport(
     : "Record<string, any>";
 
   const name = ctx.generateUniqueId("svelteComponent");
-  const componentType = `import('svelte').SvelteComponent<${propsType}, ${eventsType}, ${slotsType}>`;
+  // The *value* is the Svelte 5 `Component` function type, so `typeof Foo`
+  // matches modern usage (`mount(Foo)`, `ComponentProps<typeof Foo>`). The
+  // same-named *type* is the legacy `SvelteComponent`, so `ComponentEvents<Foo>`
+  // / `ComponentProps<Foo>` (which use `Foo` as a type) keep resolving for
+  // Svelte 4 components. Both expose the same props.
+  const valueType = `import('svelte').Component<${propsType}>`;
+  const typeType = `import('svelte').SvelteComponent<${propsType}, ${eventsType}, ${slotsType}>`;
   ctx.appendVirtualScript(
-    `declare const ${name}: ${componentType};type ${name} = ${componentType};export { ${name} as default };`,
+    `declare const ${name}: ${valueType};type ${name} = ${typeType};export { ${name} as default };`,
   );
 
   // Re-export specifier: `export { <name> as default }`.
@@ -564,10 +574,10 @@ function hasNamedTypeDeclaration(
  * With an explicit annotation it is used as-is, e.g.
  * `let { value }: { value: string } = $props()` returns `{ value: string }`.
  * Without one, a best-effort object type is inferred from the destructuring
- * pattern: each prop becomes `any`, and a default value makes it optional, e.g.
- * `let { value, count = 0 } = $props()` returns `{ value: any; count?: any }`.
- * This captures the prop names and which are required, even though the value
- * types stay `any` (annotate the props for precise types).
+ * pattern: a default value makes the prop optional and contributes its literal
+ * type, e.g. `let { value, count = 0 } = $props()` returns
+ * `{ value: any; count?: number }`. Props without a literal default stay `any`
+ * (annotate the props for fully precise types).
  *
  * Returns `null` when there is no usable `$props()` call (including legacy mode),
  * so the caller can fall back.
@@ -616,11 +626,13 @@ function getRunesPropsTypeText(
 }
 
 /**
- * Build a best-effort props object type from a `$props()` destructuring pattern,
- * e.g. `{ value, count = 0 }` becomes `{ value: any; count?: any }`. A default
- * value makes the prop optional. Returns `null` for patterns whose full shape
- * can't be enumerated (a rest element, or computed/non-identifier keys), so the
- * caller can fall back to a permissive type.
+ * Build a best-effort props object type from a `$props()` destructuring pattern.
+ * A default value makes the prop optional, and a literal default contributes its
+ * primitive type, e.g. `{ value, count = 0, name = "x" }` becomes
+ * `{ value: any; count?: number; name?: string }`. Non-literal defaults and
+ * props without a default stay `any`. Returns `null` for patterns whose full
+ * shape can't be enumerated (a rest element, or computed/non-identifier keys),
+ * so the caller can fall back to a permissive type.
  */
 function inferPropsTypeFromObjectPattern(
   pattern: TSESTree.ObjectPattern,
@@ -636,11 +648,42 @@ function inferPropsTypeFromObjectPattern(
       // the complete prop set.
       return null;
     }
-    // A default value (`AssignmentPattern`) means the prop can be omitted.
-    const optional = prop.value.type === "AssignmentPattern";
-    members.push(`${prop.key.name}${optional ? "?" : ""}: any`);
+    // A default value (`AssignmentPattern`) means the prop can be omitted, and
+    // its literal type can be recovered.
+    if (prop.value.type === "AssignmentPattern") {
+      members.push(
+        `${prop.key.name}?: ${inferTypeFromDefaultExpression(prop.value.right)}`,
+      );
+    } else {
+      members.push(`${prop.key.name}: any`);
+    }
   }
   return `{ ${members.join("; ")} }`;
+}
+
+/** Map a literal default value to its primitive type, else `any`. */
+function inferTypeFromDefaultExpression(
+  expression: TSESTree.Expression,
+): string {
+  if (expression.type === "Literal") {
+    switch (typeof expression.value) {
+      case "number":
+        return "number";
+      case "string":
+        return "string";
+      case "boolean":
+        return "boolean";
+      case "bigint":
+        return "bigint";
+      default:
+        // `null` and regex literals fall through.
+        return "any";
+    }
+  }
+  if (expression.type === "TemplateLiteral") {
+    return "string";
+  }
+  return "any";
 }
 
 /**

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -260,14 +260,14 @@ describe("synthetic component default export", () => {
     assert.match(code, /import\('svelte'\)\.SvelteComponent<\$\$Props, /);
   });
 
-  it("infers prop names and optionality from an un-annotated `$props()`", () => {
+  it("infers prop names, optionality and literal default types from an un-annotated `$props()`", () => {
     const code = translate(`<script lang="ts">
   let { value, count = 0 } = $props();
 </script>
 <p>{value}{count}</p>`);
     assert.match(
       code,
-      /import\('svelte'\)\.SvelteComponent<\{ value: any; count\?: any \}, /,
+      /import\('svelte'\)\.SvelteComponent<\{ value: any; count\?: number \}, /,
     );
   });
 
@@ -320,6 +320,23 @@ describe("synthetic component default export", () => {
     assert.match(code, /declare const (\$_svelteComponent\d+):/);
     assert.match(code, /type \$_svelteComponent\d+ = /);
     assert.match(code, /export \{ \$_svelteComponent\d+ as default \};/);
+  });
+
+  it("types the exported value as the Svelte 5 `Component` (for `typeof Foo`)", () => {
+    // The value uses `Component` so `typeof Foo` matches modern Svelte 5 usage
+    // (e.g. `mount(Foo)`), while the type alias keeps the legacy `SvelteComponent`.
+    const code = translate(`<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`);
+    assert.match(
+      code,
+      /declare const \$_svelteComponent\d+: import\('svelte'\)\.Component<\{ value: string \}>;/,
+    );
+    assert.match(
+      code,
+      /type \$_svelteComponent\d+ = import\('svelte'\)\.SvelteComponent</,
+    );
   });
 });
 
@@ -545,6 +562,61 @@ describe("imported component prop types (end-to-end type check)", () => {
       `expected no diagnostics (events permissive, Foo usable as a type), got: ${diagnostics
         .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
         .join("; ")}`,
+    );
+  });
+
+  it("works with Svelte 5 `mount(Foo, ...)` value usage", () => {
+    const runesComponent = `<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`;
+    // `mount` expects a Svelte 5 `Component`, so `typeof Foo` must be that type
+    // and the props must be checked.
+    const diagnostics = typeCheckConsumer(
+      runesComponent,
+      `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { value: "x" } });`,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      [],
+      `expected no diagnostics for mount(Foo, ...), got: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+        .join("; ")}`,
+    );
+  });
+
+  it("rejects wrong prop types via Svelte 5 `mount(Foo, ...)`", () => {
+    const runesComponent = `<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`;
+    const diagnostics = typeCheckConsumer(
+      runesComponent,
+      `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { value: 123 } });`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322 || d.code === 2769),
+      `expected a prop type error from mount(Foo, ...), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("enforces literal default types inferred from an un-annotated `$props()`", () => {
+    const inferredComponent = `<script lang="ts">
+  let { count = 0 } = $props();
+</script>
+<p>{count}</p>`;
+    // `count = 0` makes `count?: number`, so a string must error for importers.
+    const diagnostics = typeCheckConsumer(
+      inferredComponent,
+      `const count: import("svelte").ComponentProps<typeof Foo>["count"] = "x";`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (string not assignable to number), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
     );
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> Alpha-stage work **authored by Claude Code** (AI), published as a draft for early review only. Behavior/API may change or be dropped.

> [!NOTE]
> **Stacked on #910** (→ #909 → #908 → #907 → #906 → #905). Review the parents first.

## What

Follow-up that **completes Svelte 5 support** for the synthetic component export, addressing the two Svelte-5-specific gaps found while reviewing #905–#910.

### 1. `typeof Foo` is now the Svelte 5 `Component` (value usage / `mount`)

#910 typed the exported *value* as `SvelteComponent` (a legacy class instance). That made template prop checks work, but `typeof Foo` was wrong for modern Svelte 5 value usage — e.g. `mount(Foo, …)` expects `Component<…>`, so it errored.

Now the value is `Component<Props>` while the same-named **type** alias stays `SvelteComponent<Props, Events, Slots>`:

```ts
declare const $c: import('svelte').Component<Props>;
type $c = import('svelte').SvelteComponent<Props, Events, Slots>;
export { $c as default };
```

- `typeof Foo` → `Component<Props>` → `mount(Foo, { props })` ✓, `ComponentProps<typeof Foo>` ✓
- `Foo` as a type → `SvelteComponent<…>` → `ComponentEvents<Foo>` ✓ (Svelte 4 unchanged)

### 2. Literal default types from un-annotated `$props()`

`let { value, count = 0, name = "x" } = $props()` now yields `Component<{ value: any; count?: number; name?: string }>` (was `count?: any`). Non-literal defaults and undefaulted props stay `any` — matching what svelte2tsx can recover.

## Verified

- Full suite green (`8684 passing`), incl. AST/scope invariance.
- New unit tests: value is `Component`, type alias is `SvelteComponent`; literal default inference.
- New **end-to-end `tsc` tests**: `mount(Foo, { props })` type-checks and rejects wrong prop types; un-annotated `count = 0` rejects a string for importers.

## Honest scope

This makes **idiomatic, well-typed Svelte 5 components** fully correct for importers (annotated `$props()`, `$bindable`, snippet/callback-event props, `mount`). Still approximate: un-annotated **undefaulted** props and **non-literal** defaults stay `any` (the author didn't type them; svelte2tsx is the same), and the feature remains gated on the experimental `ts.sys.readFile` hook.

## Series

- #905 runes `$props()` · #906 `export let` · #907 `$$Props` · #908 un-annotated inference · #909 generics · #910 events/slots · **this** Svelte 5 completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)