### PR TITLE
WIP (alpha): resolve component prop/event/slot types for importers (Svelte 3/4/5)

### DIFF
--- a/.changeset/svelte5-component-prop-types.md
+++ b/.changeset/svelte5-component-prop-types.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+Emit a synthetic component `export default` in the virtual TypeScript so importers of a `.svelte` component can resolve its prop, event, and slot types. The experimental `ts.sys` hook (`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`) now also resolves `.svelte` import specifiers to that virtual code, so `ComponentProps<typeof Foo>` and `mount(Foo, …)` work across files. The synthetic statements are removed again on restore, so the linted file is unaffected. Experimental, alpha-stage. See the Experimental section in the README for details and limitations.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,18 @@ SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1 \
   eslint --no-cache --concurrency auto .
 ```
 
+When enabled, the hook also resolves `.svelte` import specifiers to the
+imported component's virtual module, so type-aware rules see a component's
+real prop, event, and slot types across files. `import Foo from "./Foo.svelte"`
+is resolved through a virtual `Foo.svelte.ts` companion that the hook serves
+from the same translation — no `tsconfig` changes are required. If a real
+`Foo.svelte.ts` (a Svelte runes module) exists on disk, it always takes
+precedence and the hook leaves it untouched. In that case component prop types
+are not available for that component, because plain TypeScript resolution picks
+the module instead of the component. To avoid this name collision, enable the
+`svelte/no-conflicting-module-names` rule from `eslint-plugin-svelte` (v3.22.0
+or later), which reports a `Foo.svelte` and `Foo.svelte.ts` pair.
+
 Caveat: rules that read raw TypeScript diagnostics
 (`program.getSemanticDiagnostics()` and friends) report positions inside
 the parser's virtual shim — a pre-existing property of type-aware Svelte

--- a/src/parser/compat.ts
+++ b/src/parser/compat.ts
@@ -29,6 +29,30 @@ export function getModuleFromRoot(
 ): SvAST.Script | Compiler.Script | null | undefined {
   return svelteAst.module;
 }
+
+/**
+ * Source range of the instance `<script>` content, in original-source
+ * coordinates. Used to tell instance-script statements apart from module-script
+ * ones, which the virtual code concatenates.
+ */
+export function getInstanceScriptRange(
+  svelteAst: Compiler.Root | SvAST.AstLegacy,
+): [number, number] | null {
+  const instance = getInstanceFromRoot(svelteAst);
+  if (!instance) {
+    return null;
+  }
+  const content = (instance as { content?: { start?: number; end?: number } })
+    .content;
+  if (
+    content &&
+    typeof content.start === "number" &&
+    typeof content.end === "number"
+  ) {
+    return [content.start, content.end];
+  }
+  return [instance.start, instance.end];
+}
 export function getOptionsFromRoot(
   svelteAst: Compiler.Root | SvAST.AstLegacy,
 ): Compiler.SvelteOptionsRaw | null {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -48,7 +48,7 @@ import {
 import { getGlobalsForSvelte, getGlobalsForSvelteScript } from "./globals.js";
 import type { NormalizedParserOptions } from "./parser-options.js";
 import { isTypeScript, normalizeParserOptions } from "./parser-options.js";
-import { getFragmentFromRoot } from "./compat.js";
+import { getFragmentFromRoot, getInstanceScriptRange } from "./compat.js";
 import {
   hasRunesSymbol,
   resolveSvelteParseContextForSvelte,
@@ -162,7 +162,11 @@ function parseAsSvelte(
         scripts.getCurrentVirtualCodeInfo(),
         scripts.attrs,
         parserOptions,
-        { slots: ctx.slots, svelteParseContext },
+        {
+          slots: ctx.slots,
+          svelteParseContext,
+          instanceScriptRange: getInstanceScriptRange(resultTemplate.svelteAst),
+        },
       )
     : parseScriptInSvelte(
         scripts.getCurrentVirtualCode(),

--- a/src/parser/svelte-to-virtual-ts.ts
+++ b/src/parser/svelte-to-virtual-ts.ts
@@ -4,6 +4,7 @@ import type { NormalizedParserOptions } from "./parser-options.js";
 import { parseTemplate } from "./template.js";
 import { analyzeTypeScriptInSvelte } from "./typescript/analyze/index.js";
 import { resolveSvelteParseContextForSvelte } from "./svelte-parse-context.js";
+import { getInstanceScriptRange } from "./compat.js";
 
 /**
  * Translate a Svelte component to the virtual TypeScript shim. Returns
@@ -45,7 +46,11 @@ export function svelteToVirtualTypeScript(
       scripts.getCurrentVirtualCodeInfo(),
       scripts.attrs,
       inner,
-      { slots: ctx.slots, svelteParseContext },
+      {
+        slots: ctx.slots,
+        svelteParseContext,
+        instanceScriptRange: getInstanceScriptRange(template.svelteAst),
+      },
     );
     return tsCtx.script;
   } catch {

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -702,6 +702,9 @@ function inferPropsFromObjectPattern(
 ): RecoveredProps {
   const members: string[] = [];
   const defaulted: string[] = [];
+  // A prop can be destructured twice (`{ a, a: b }`, `{ 1e3: p, 1_000: q }`);
+  // emitting the key twice would be a TS2300 duplicate identifier.
+  const seen = new Set<string>();
   let open = false;
   for (const prop of pattern.properties) {
     if (prop.type !== "Property") {
@@ -711,18 +714,25 @@ function inferPropsFromObjectPattern(
     // Keys are taken raw so a string key keeps its quotes. A literal key is
     // resolvable even when computed (`["a"]`), unlike an identifier one (`[k]`).
     // Bigint keys are excluded: `0n` is not a valid type-literal key.
-    let key: string;
+    let key: string, normalized: string;
     if (!prop.computed && prop.key.type === "Identifier") {
       key = prop.key.name;
+      normalized = prop.key.name;
     } else if (
       prop.key.type === "Literal" &&
       (typeof prop.key.value === "string" || typeof prop.key.value === "number")
     ) {
       key = prop.key.raw;
+      // `String` matches `ToPropertyKey`, so `1e3`, `1_000` and `"1000"` agree.
+      normalized = String(prop.key.value);
     } else {
       open = true;
       continue;
     }
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
     if (prop.value.type === "AssignmentPattern") {
       const def = stripAsConst(prop.value.right);
       const degraded = degenerateDefaultType(def);

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -569,18 +569,11 @@ function referencesOpenProps(
 }
 
 type RecoveredProps = {
-  /**
-   * Type text contributed directly: the whole props type for an explicit
-   * annotation/cast, or just the required members when inferred from a
-   * destructuring. `null` when there is nothing to contribute.
-   */
+  /** The whole props type when annotated, else only the required members. */
   type: string | null;
   /** Probe object literal of defaulted props (`{ count: 0 }`), or `null`. */
   probe: string | null;
-  /**
-   * Whether the prop set could not be fully enumerated, so the type must stay
-   * open with an index signature.
-   */
+  /** The props could not be fully enumerated, so the type must stay open. */
   open: boolean;
 };
 
@@ -651,13 +644,9 @@ function recoverRunesProps(
 }
 
 /**
- * Defaulted props go into a probe object so TS can infer their type from the
- * default expression via `typeof`. A prop with no default becomes a required
- * `any`, matching svelte2tsx: the name is known but nothing types it, so being
- * required is the only signal left to give importers.
- *
- * A rest element or a computed key can't be enumerated, so it only opens the
- * type rather than discarding the props that could be read.
+ * Defaults go through a probe object because only TS can type the default
+ * expression; a prop with no default has no type source at all, so it stays a
+ * required `any`, as in svelte2tsx.
  */
 function inferPropsFromObjectPattern(
   pattern: TSESTree.ObjectPattern,

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -244,7 +244,12 @@ function appendComponentDefaultExport(
   // Runes `$props()` takes precedence over legacy recovery; the last fallback
   // stays permissive so `typeof Foo` still resolves.
   let propsType: string;
-  const runesProps = recoverRunesProps(result, source, svelteParseContext);
+  const runesProps = recoverRunesProps(
+    result,
+    source,
+    svelteParseContext,
+    instanceScriptRange,
+  );
   if (runesProps != null) {
     const parts: string[] = [];
     if (runesProps.probe != null) {
@@ -569,7 +574,7 @@ function referencesOpenProps(
 }
 
 type RecoveredProps = {
-  /** The whole props type when annotated, else only the required members. */
+  /** The whole props type when annotated, else the members recovered from the pattern. */
   type: string | null;
   /** Probe object literal of defaulted props (`{ count: 0 }`), or `null`. */
   probe: string | null;
@@ -581,17 +586,31 @@ type RecoveredProps = {
  * Recover props from a runes `$props()` declaration. An explicit annotation,
  * `as`, or `satisfies` type is used as-is; otherwise the type is inferred from
  * the destructuring.
+ *
+ * Only a top-level instance-script declaration counts, since that is the only
+ * place Svelte accepts `$props()`; a `<script module>` call must not hijack the
+ * real declaration.
  */
 function recoverRunesProps(
   result: TSESParseForESLintResult,
   source: string,
   svelteParseContext: SvelteParseContext,
+  instanceScriptRange: [number, number] | null,
 ): RecoveredProps | null {
-  if (svelteParseContext.runes === false) {
+  if (svelteParseContext.runes === false || !instanceScriptRange) {
     return null;
   }
+  const [instanceStart, instanceEnd] = instanceScriptRange;
   const propsReferences = result.scopeManager.globalScope!.through.filter(
-    (reference) => reference.identifier.name === "$props",
+    (reference) => {
+      const { name, range } = reference.identifier;
+      return (
+        name === "$props" &&
+        range != null &&
+        instanceStart <= range[0] &&
+        range[1] <= instanceEnd
+      );
+    },
   );
   if (!propsReferences.length) {
     return null;
@@ -615,7 +634,8 @@ function recoverRunesProps(
     }
     if (
       valueNode.parent?.type !== "VariableDeclarator" ||
-      valueNode.parent.init !== valueNode
+      valueNode.parent.init !== valueNode ||
+      !isTopLevelDeclarator(valueNode.parent)
     ) {
       continue;
     }
@@ -643,6 +663,17 @@ function recoverRunesProps(
   return null;
 }
 
+function isTopLevelDeclarator(
+  declarator: TSESTree.VariableDeclarator,
+): boolean {
+  const declaration = declarator.parent;
+  const statement =
+    declaration.parent?.type === "ExportNamedDeclaration"
+      ? declaration.parent
+      : declaration;
+  return statement.parent?.type === "Program";
+}
+
 /**
  * Defaults go through a probe object because only TS can type the default
  * expression; a prop with no default has no type source at all, so it stays a
@@ -652,7 +683,7 @@ function inferPropsFromObjectPattern(
   pattern: TSESTree.ObjectPattern,
   source: string,
 ): RecoveredProps {
-  const required: string[] = [];
+  const members: string[] = [];
   const defaulted: string[] = [];
   let open = false;
   for (const prop of pattern.properties) {
@@ -675,16 +706,46 @@ function inferPropsFromObjectPattern(
     }
     if (prop.value.type === "AssignmentPattern") {
       const def = prop.value.right;
-      defaulted.push(`${key}: ${source.slice(def.range[0], def.range[1])}`);
+      const degraded = degenerateDefaultType(def);
+      if (degraded != null) {
+        members.push(`${key}?: ${degraded}`);
+        continue;
+      }
+      // ESTree ranges exclude wrapping parens, so a sequence expression default
+      // would slice to `1, 2` and make the probe object literal invalid.
+      defaulted.push(`${key}: (${source.slice(def.range[0], def.range[1])})`);
     } else {
-      required.push(`${key}: any`);
+      members.push(`${key}: any`);
     }
   }
   return {
-    type: required.length ? `{ ${required.join("; ")} }` : null,
+    type: members.length ? `{ ${members.join("; ")} }` : null,
     probe: defaulted.length ? `{ ${defaulted.join(", ")} }` : null,
     open,
   };
+}
+
+/**
+ * Defaults that TS can only infer as an uninhabitable type (`never[]`, `null`,
+ * `undefined`), which would reject every value an importer can pass. svelte2tsx
+ * degrades them to `any` for the same reason.
+ */
+function degenerateDefaultType(node: TSESTree.Expression): string | null {
+  if (node.type === "ArrayExpression" && node.elements.length === 0) {
+    return "any[]";
+  }
+  // `raw` distinguishes the null literal from a regex literal, whose `value` is
+  // also null when the environment cannot build the `RegExp`.
+  if (node.type === "Literal" && node.raw === "null") {
+    return "any";
+  }
+  if (node.type === "Identifier" && node.name === "undefined") {
+    return "any";
+  }
+  if (node.type === "UnaryExpression" && node.operator === "void") {
+    return "any";
+  }
+  return null;
 }
 
 /**

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -24,10 +24,13 @@ import { setParent } from "../set-parent.js";
 import { getGlobalsForSvelte, globalsForRunes } from "../../globals.js";
 import type { SvelteParseContext } from "../../svelte-parse-context.js";
 import { withoutProjectParserOptions } from "../../parser-options.js";
+import { svelteVersion } from "../../svelte-version.js";
 
 export type AnalyzeTypeScriptContext = {
   slots: Set<SvelteHTMLElement>;
   svelteParseContext: SvelteParseContext;
+  /** Source range of the instance `<script>` content; the virtual code concatenates both scripts. */
+  instanceScriptRange?: [number, number] | null;
 };
 
 type TransformInfo = {
@@ -152,6 +155,15 @@ export function analyzeTypeScriptInSvelte(
 
   ctx.appendOriginalToEnd();
 
+  // Emitted last so it lands as a standalone top-level statement.
+  appendComponentDefaultExport(
+    result,
+    code.script + code.render + code.rootScope,
+    ctx,
+    context.svelteParseContext,
+    context.instanceScriptRange ?? null,
+  );
+
   return ctx;
 }
 /**
@@ -198,6 +210,468 @@ function hasExportDeclaration(ast: TSESParseForESLintResult["ast"]): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Append a synthetic component `export default` so importers can resolve the
+ * component's prop, event, and slot types.
+ *
+ * The export must carry both a value and a type meaning: `ComponentProps<typeof
+ * Foo>` uses the value, while `ComponentEvents<Foo>` and Svelte-4-style
+ * `ComponentProps<Foo>` use `Foo` as a type. A bare `export default <expr>` only
+ * provides the value, so emit a value/type pair re-exported as default.
+ */
+function appendComponentDefaultExport(
+  result: TSESParseForESLintResult,
+  source: string,
+  ctx: VirtualTypeScriptContext,
+  svelteParseContext: SvelteParseContext,
+  instanceScriptRange: [number, number] | null,
+) {
+  if (hasDefaultExport(result.ast)) {
+    return;
+  }
+
+  // Legacy recovery must only look at the instance script: a module-context
+  // `export let` is not a prop, and `$$Props`/`$$Events`/`$$Slots` are only
+  // meaningful in the instance script.
+  const instanceStatements = getInstanceStatements(result, instanceScriptRange);
+
+  const names: string[] = [];
+  // Lead with a newline so a trailing line comment can't swallow the statement.
+  let code = "\n";
+
+  // Runes `$props()` takes precedence over legacy recovery; the last fallback
+  // stays permissive so `typeof Foo` still resolves.
+  let propsType: string;
+  const runesProps = recoverRunesProps(result, source, svelteParseContext);
+  if (runesProps != null) {
+    if (runesProps.probe != null) {
+      // Let TS infer the default value types via `typeof` of a probe object.
+      const probeName = ctx.generateUniqueId("propsProbe");
+      names.push(probeName);
+      code += `const ${probeName} = ${runesProps.probe};`;
+      propsType = runesProps.type
+        ? `Partial<typeof ${probeName}> & ${runesProps.type}`
+        : `Partial<typeof ${probeName}>`;
+    } else {
+      propsType = runesProps.type || "{}";
+    }
+  } else {
+    // A component reading `$$props`/`$$restProps` accepts arbitrary attributes,
+    // so the synthesized (closed) type is opened with an index signature to
+    // avoid spurious excess-property errors. `$$Props` is exempt: there the user
+    // owns the open/closed decision.
+    const dollarPropsType = getDollarDollarPropsType(
+      instanceStatements,
+      svelteParseContext,
+    );
+    if (dollarPropsType != null) {
+      propsType = dollarPropsType;
+    } else {
+      const exportLetType = getLegacyExportLetPropsType(
+        instanceStatements,
+        source,
+        svelteParseContext,
+      );
+      if (
+        exportLetType != null &&
+        referencesOpenProps(result, instanceScriptRange)
+      ) {
+        propsType = `${exportLetType} & { [key: string]: any }`;
+      } else {
+        propsType = exportLetType ?? "Record<string, any>";
+      }
+    }
+  }
+
+  // Stay permissive without `$$Events`/`$$Slots` so `on:` and slots don't get
+  // spurious errors.
+  const eventsType = hasNamedTypeDeclaration(instanceStatements, "$$Events")
+    ? "$$Events"
+    : "Record<string, any>";
+  const slotsType = hasNamedTypeDeclaration(instanceStatements, "$$Slots")
+    ? "$$Slots"
+    : "Record<string, any>";
+
+  const name = ctx.generateUniqueId("svelteComponent");
+  names.push(name);
+  const { valueType, typeType } = componentTypeText(
+    propsType,
+    eventsType,
+    slotsType,
+  );
+  code += `declare const ${name}: ${valueType};type ${name} = ${typeType};export { ${name} as default };`;
+  ctx.appendVirtualScript(code);
+
+  // `export { <name> as default }`.
+  registerRemoval(
+    ctx,
+    (node) =>
+      node.type === "ExportNamedDeclaration" &&
+      node.declaration == null &&
+      node.specifiers.length === 1 &&
+      node.specifiers[0].local.type === "Identifier" &&
+      node.specifiers[0].local.name === name,
+  );
+  // `type <name> = ...`.
+  registerRemoval(
+    ctx,
+    (node) => node.type === "TSTypeAliasDeclaration" && node.id.name === name,
+  );
+  // The `declare const <name>` and any props probe const.
+  for (const nm of names) {
+    registerRemoval(
+      ctx,
+      (node) =>
+        node.type === "VariableDeclaration" &&
+        node.declarations[0]?.id.type === "Identifier" &&
+        node.declarations[0].id.name === nm,
+    );
+  }
+}
+
+/**
+ * Value-side and type-side text of the synthetic default export, chosen by the
+ * *installed* Svelte version rather than the component mode: Svelte 3/4 typings
+ * have no `Component`, and Svelte 3's `SvelteComponent` is not generic.
+ */
+function componentTypeText(
+  propsType: string,
+  eventsType: string,
+  slotsType: string,
+): { valueType: string; typeType: string } {
+  const typeArgs = `<${propsType}, ${eventsType}, ${slotsType}>`;
+  if (svelteVersion.gte(5)) {
+    // The value is Svelte 5's `Component` so `typeof Foo` matches modern usage;
+    // the same-named legacy `SvelteComponent` type keeps `ComponentEvents<Foo>`
+    // resolving.
+    return {
+      valueType: `import('svelte').Component<${propsType}>`,
+      typeType: `import('svelte').SvelteComponent${typeArgs}`,
+    };
+  }
+  const className = svelteVersion.gte(4)
+    ? "SvelteComponent"
+    : "SvelteComponentTyped";
+  const instanceType = `import('svelte').${className}${typeArgs}`;
+  // A constructor value so `new Foo(...)` works and `typeof Foo` resolves; the
+  // same-named type is the instance for `ComponentProps<Foo>` /
+  // `ComponentEvents<Foo>`. `ComponentConstructorOptions` (present in Svelte 3
+  // and 4) validates `new Foo({ props: … })` instead of accepting anything.
+  return {
+    valueType: `new (options: import('svelte').ComponentConstructorOptions<${propsType}>) => ${instanceType}`,
+    typeType: instanceType,
+  };
+}
+
+/** Register a restore process that splices a matching statement and cleans scope. */
+function registerRemoval(
+  ctx: VirtualTypeScriptContext,
+  match: (node: TSESTree.Node) => boolean,
+) {
+  ctx.restoreContext.addRestoreStatementProcess((node, result) => {
+    if (!match(node as TSESTree.Node)) {
+      return false;
+    }
+    result.ast.body.splice(result.ast.body.indexOf(node as never), 1);
+    removeAllScopeAndVariableAndReference(node as TSESTree.Node, {
+      visitorKeys: result.visitorKeys,
+      scopeManager: result.scopeManager as eslint.Scope.ScopeManager,
+    });
+    return true;
+  });
+}
+
+function hasDefaultExport(ast: TSESParseForESLintResult["ast"]): boolean {
+  return ast.body.some((node) => {
+    if (node.type === "ExportDefaultDeclaration") {
+      return true;
+    }
+    // `export { x as default }` counts as a user-authored default export too.
+    if (node.type === "ExportNamedDeclaration") {
+      return node.specifiers.some(
+        (specifier) =>
+          specifier.exported.type === "Identifier" &&
+          specifier.exported.name === "default",
+      );
+    }
+    return false;
+  });
+}
+
+/** Top-level statements of the instance `<script>`, filtered out of the concatenated body by source range. */
+function getInstanceStatements(
+  result: TSESParseForESLintResult,
+  instanceScriptRange: [number, number] | null,
+): TSESTree.ProgramStatement[] {
+  if (!instanceScriptRange) {
+    return [];
+  }
+  const [start, end] = instanceScriptRange;
+  return result.ast.body.filter(
+    (node) => start <= node.range[0] && node.range[1] <= end,
+  );
+}
+
+function hasNamedTypeDeclaration(
+  statements: TSESTree.ProgramStatement[],
+  name: string,
+): boolean {
+  return statements.some(
+    (node) =>
+      (node.type === "TSInterfaceDeclaration" ||
+        node.type === "TSTypeAliasDeclaration") &&
+      node.id.name === name,
+  );
+}
+
+/**
+ * Svelte treats `$$Props` as the authoritative prop typing, so it takes priority
+ * over `export let` inference. Referenced by name, since the declaration itself
+ * stays in the virtual code.
+ */
+function getDollarDollarPropsType(
+  instanceStatements: TSESTree.ProgramStatement[],
+  svelteParseContext: SvelteParseContext,
+): string | null {
+  if (svelteParseContext.runes === true) {
+    return null;
+  }
+  return hasNamedTypeDeclaration(instanceStatements, "$$Props")
+    ? "$$Props"
+    : null;
+}
+
+/**
+ * Synthesize a props object type from legacy prop declarations, mirroring
+ * svelte2tsx: a default value makes the prop optional, an explicit annotation is
+ * used as-is, otherwise the type is inferred via `typeof`. Renamed exports whose
+ * local is a top-level `let` (`export { className as class }`) are props too.
+ */
+function getLegacyExportLetPropsType(
+  instanceStatements: TSESTree.ProgramStatement[],
+  source: string,
+  svelteParseContext: SvelteParseContext,
+): string | null {
+  // `export let` is only a prop declaration in legacy (non-runes) mode.
+  if (svelteParseContext.runes === true) {
+    return null;
+  }
+  const members: string[] = [];
+
+  function pushMember(
+    exportedName: string,
+    declarator: TSESTree.LetOrConstOrVarDeclarator,
+  ): void {
+    const optional = declarator.init != null;
+    const typeAnnotation =
+      declarator.id.type === "Identifier"
+        ? declarator.id.typeAnnotation
+        : undefined;
+    const localName =
+      declarator.id.type === "Identifier" ? declarator.id.name : null;
+    const typeText = typeAnnotation
+      ? source.slice(
+          typeAnnotation.typeAnnotation.range[0],
+          typeAnnotation.typeAnnotation.range[1],
+        )
+      : localName != null
+        ? `typeof ${localName}`
+        : "any";
+    members.push(`${propKey(exportedName)}${optional ? "?" : ""}: ${typeText}`);
+  }
+
+  // Indexed by binding name so a renamed export can resolve its local `let`.
+  const letDeclarators = new Map<string, TSESTree.LetOrConstOrVarDeclarator>();
+  for (const node of instanceStatements) {
+    const decl =
+      node.type === "ExportNamedDeclaration" ? node.declaration : node;
+    if (decl?.type !== "VariableDeclaration" || decl.kind !== "let") {
+      continue;
+    }
+    for (const declarator of decl.declarations) {
+      if (declarator.id.type === "Identifier") {
+        letDeclarators.set(declarator.id.name, declarator);
+      }
+    }
+  }
+
+  for (const node of instanceStatements) {
+    if (node.type !== "ExportNamedDeclaration") {
+      continue;
+    }
+    if (
+      node.declaration?.type === "VariableDeclaration" &&
+      node.declaration.kind === "let"
+    ) {
+      for (const declarator of node.declaration.declarations) {
+        if (declarator.id.type !== "Identifier") {
+          continue;
+        }
+        pushMember(declarator.id.name, declarator);
+      }
+      continue;
+    }
+    // A renamed (or same-name) export of a top-level `let` binding is a prop.
+    // Skip re-exports (`export … from '…'`) and `default` (handled elsewhere).
+    if (node.declaration == null && node.source == null) {
+      for (const specifier of node.specifiers) {
+        if (
+          specifier.local.type !== "Identifier" ||
+          specifier.exported.type !== "Identifier" ||
+          specifier.exported.name === "default"
+        ) {
+          continue;
+        }
+        const declarator = letDeclarators.get(specifier.local.name);
+        if (!declarator) {
+          continue;
+        }
+        pushMember(specifier.exported.name, declarator);
+      }
+    }
+  }
+  if (!members.length) {
+    return null;
+  }
+  return `{ ${members.join("; ")} }`;
+}
+
+/** Quote non-identifier keys so reserved-word prop names like `class` are emitted safely. */
+function propKey(name: string): string {
+  return /^[$A-Z_a-z][\w$]*$/u.test(name) ? name : JSON.stringify(name);
+}
+
+/** Whether the instance script references `$$props` or `$$restProps`. */
+function referencesOpenProps(
+  result: TSESParseForESLintResult,
+  instanceScriptRange: [number, number] | null,
+): boolean {
+  if (!instanceScriptRange) {
+    return false;
+  }
+  const [start, end] = instanceScriptRange;
+  return result.scopeManager.globalScope!.through.some((reference) => {
+    const { name, range } = reference.identifier;
+    return (
+      (name === "$$props" || name === "$$restProps") &&
+      range != null &&
+      start <= range[0] &&
+      range[1] <= end
+    );
+  });
+}
+
+type RecoveredProps = {
+  /** Props type text, or `""` when every prop is optional (all defaulted). */
+  type: string;
+  /** Probe object literal of defaulted props (`{ count: 0 }`), or `null`. */
+  probe: string | null;
+};
+
+/**
+ * Recover props from a runes `$props()` declaration. An explicit annotation,
+ * `as`, or `satisfies` type is used as-is; otherwise the type is inferred from
+ * the destructuring.
+ */
+function recoverRunesProps(
+  result: TSESParseForESLintResult,
+  source: string,
+  svelteParseContext: SvelteParseContext,
+): RecoveredProps | null {
+  if (svelteParseContext.runes === false) {
+    return null;
+  }
+  const propsReferences = result.scopeManager.globalScope!.through.filter(
+    (reference) => reference.identifier.name === "$props",
+  );
+  if (!propsReferences.length) {
+    return null;
+  }
+  setParent(result);
+  for (const reference of propsReferences) {
+    const id = reference.identifier as TSESTree.Identifier;
+    const call = id.parent;
+    if (call?.type !== "CallExpression" || call.callee !== id) {
+      continue;
+    }
+    // A trailing `as`/`satisfies` cast carries the type, between call and declarator.
+    let valueNode: TSESTree.Expression = call;
+    let castType: TSESTree.TypeNode | null = null;
+    if (
+      call.parent?.type === "TSAsExpression" ||
+      call.parent?.type === "TSSatisfiesExpression"
+    ) {
+      castType = call.parent.typeAnnotation;
+      valueNode = call.parent;
+    }
+    if (
+      valueNode.parent?.type !== "VariableDeclarator" ||
+      valueNode.parent.init !== valueNode
+    ) {
+      continue;
+    }
+    if (castType) {
+      return {
+        type: source.slice(castType.range[0], castType.range[1]),
+        probe: null,
+      };
+    }
+    const declId = valueNode.parent.id;
+    const annotation = declId.typeAnnotation;
+    if (annotation) {
+      const node = annotation.typeAnnotation;
+      return { type: source.slice(node.range[0], node.range[1]), probe: null };
+    }
+    if (declId.type === "ObjectPattern") {
+      const inferred = inferPropsFromObjectPattern(declId, source);
+      if (inferred != null) {
+        return inferred;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Required props become `any`; defaulted props go into a probe object so TS can
+ * infer their type from the default expression via `typeof`. Returns `null` for
+ * a rest element or a computed key, where the prop set can't be enumerated.
+ */
+function inferPropsFromObjectPattern(
+  pattern: TSESTree.ObjectPattern,
+  source: string,
+): RecoveredProps | null {
+  const required: string[] = [];
+  const defaulted: string[] = [];
+  for (const prop of pattern.properties) {
+    if (prop.type !== "Property" || prop.computed) {
+      return null;
+    }
+    // String-literal keys are taken raw, so their quotes are preserved.
+    let key: string;
+    if (prop.key.type === "Identifier") {
+      key = prop.key.name;
+    } else if (
+      prop.key.type === "Literal" &&
+      typeof prop.key.value === "string"
+    ) {
+      key = prop.key.raw;
+    } else {
+      return null;
+    }
+    if (prop.value.type === "AssignmentPattern") {
+      const def = prop.value.right;
+      defaulted.push(`${key}: ${source.slice(def.range[0], def.range[1])}`);
+    } else {
+      required.push(`${key}: any`);
+    }
+  }
+  return {
+    type: required.length ? `{ ${required.join("; ")} }` : "",
+    probe: defaulted.length ? `{ ${defaulted.join(", ")} }` : null,
+  };
 }
 
 /**

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -246,17 +246,22 @@ function appendComponentDefaultExport(
   let propsType: string;
   const runesProps = recoverRunesProps(result, source, svelteParseContext);
   if (runesProps != null) {
+    const parts: string[] = [];
     if (runesProps.probe != null) {
       // Let TS infer the default value types via `typeof` of a probe object.
       const probeName = ctx.generateUniqueId("propsProbe");
       names.push(probeName);
       code += `const ${probeName} = ${runesProps.probe};`;
-      propsType = runesProps.type
-        ? `Partial<typeof ${probeName}> & ${runesProps.type}`
-        : `Partial<typeof ${probeName}>`;
-    } else {
-      propsType = runesProps.type || "{}";
+      parts.push(`Partial<typeof ${probeName}>`);
     }
+    if (runesProps.type != null) {
+      parts.push(runesProps.type);
+    }
+    if (runesProps.open) {
+      parts.push("Record<string, any>");
+    }
+    // An empty destructuring declares no props at all, so nothing is accepted.
+    propsType = parts.length ? parts.join(" & ") : "Record<string, never>";
   } else {
     // A component reading `$$props`/`$$restProps` accepts arbitrary attributes,
     // so the synthesized (closed) type is opened with an index signature to
@@ -564,10 +569,19 @@ function referencesOpenProps(
 }
 
 type RecoveredProps = {
-  /** Props type text, or `""` when every prop is optional (all defaulted). */
-  type: string;
+  /**
+   * Type text contributed directly: the whole props type for an explicit
+   * annotation/cast, or just the required members when inferred from a
+   * destructuring. `null` when there is nothing to contribute.
+   */
+  type: string | null;
   /** Probe object literal of defaulted props (`{ count: 0 }`), or `null`. */
   probe: string | null;
+  /**
+   * Whether the prop set could not be fully enumerated, so the type must stay
+   * open with an index signature.
+   */
+  open: boolean;
 };
 
 /**
@@ -616,38 +630,46 @@ function recoverRunesProps(
       return {
         type: source.slice(castType.range[0], castType.range[1]),
         probe: null,
+        open: false,
       };
     }
     const declId = valueNode.parent.id;
     const annotation = declId.typeAnnotation;
     if (annotation) {
       const node = annotation.typeAnnotation;
-      return { type: source.slice(node.range[0], node.range[1]), probe: null };
+      return {
+        type: source.slice(node.range[0], node.range[1]),
+        probe: null,
+        open: false,
+      };
     }
     if (declId.type === "ObjectPattern") {
-      const inferred = inferPropsFromObjectPattern(declId, source);
-      if (inferred != null) {
-        return inferred;
-      }
+      return inferPropsFromObjectPattern(declId, source);
     }
   }
   return null;
 }
 
 /**
- * Required props become `any`; defaulted props go into a probe object so TS can
- * infer their type from the default expression via `typeof`. Returns `null` for
- * a rest element or a computed key, where the prop set can't be enumerated.
+ * Defaulted props go into a probe object so TS can infer their type from the
+ * default expression via `typeof`. A prop with no default becomes a required
+ * `any`, matching svelte2tsx: the name is known but nothing types it, so being
+ * required is the only signal left to give importers.
+ *
+ * A rest element or a computed key can't be enumerated, so it only opens the
+ * type rather than discarding the props that could be read.
  */
 function inferPropsFromObjectPattern(
   pattern: TSESTree.ObjectPattern,
   source: string,
-): RecoveredProps | null {
+): RecoveredProps {
   const required: string[] = [];
   const defaulted: string[] = [];
+  let open = false;
   for (const prop of pattern.properties) {
     if (prop.type !== "Property" || prop.computed) {
-      return null;
+      open = true;
+      continue;
     }
     // String-literal keys are taken raw, so their quotes are preserved.
     let key: string;
@@ -659,7 +681,8 @@ function inferPropsFromObjectPattern(
     ) {
       key = prop.key.raw;
     } else {
-      return null;
+      open = true;
+      continue;
     }
     if (prop.value.type === "AssignmentPattern") {
       const def = prop.value.right;
@@ -669,8 +692,9 @@ function inferPropsFromObjectPattern(
     }
   }
   return {
-    type: required.length ? `{ ${required.join("; ")} }` : "",
+    type: required.length ? `{ ${required.join("; ")} }` : null,
     probe: defaulted.length ? `{ ${defaulted.join(", ")} }` : null,
+    open,
   };
 }
 

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -250,7 +250,9 @@ function appendComponentDefaultExport(
     svelteParseContext,
     instanceScriptRange,
   );
-  if (runesProps != null) {
+  if (runesProps?.kind === "explicit") {
+    propsType = runesProps.type;
+  } else if (runesProps != null) {
     const parts: string[] = [];
     if (runesProps.probe != null) {
       // Let TS infer the default value types via `typeof` of a probe object.
@@ -259,8 +261,8 @@ function appendComponentDefaultExport(
       code += `const ${probeName} = ${runesProps.probe};`;
       parts.push(`Partial<typeof ${probeName}>`);
     }
-    if (runesProps.type != null) {
-      parts.push(runesProps.type);
+    if (runesProps.members != null) {
+      parts.push(runesProps.members);
     }
     if (runesProps.open) {
       parts.push("Record<string, any>");
@@ -573,14 +575,22 @@ function referencesOpenProps(
   });
 }
 
-type RecoveredProps = {
-  /** The whole props type when annotated, else the members recovered from the pattern. */
-  type: string | null;
-  /** Probe object literal of defaulted props (`{ count: 0 }`), or `null`. */
-  probe: string | null;
-  /** The props could not be fully enumerated, so the type must stay open. */
-  open: boolean;
-};
+/**
+ * The two paths are kept apart because `explicit` carries a whole user-written
+ * type, which may be a union: intersecting it with anything else would mis-bind,
+ * since `&` binds tighter than `|`.
+ */
+type RecoveredProps =
+  | { kind: "explicit"; type: string }
+  | {
+      kind: "inferred";
+      /** Members recovered from the destructuring pattern, or `null`. */
+      members: string | null;
+      /** Probe object literal of defaulted props (`{ count: 0 }`), or `null`. */
+      probe: string | null;
+      /** The props could not be fully enumerated, so the type must stay open. */
+      open: boolean;
+    };
 
 /**
  * Recover props from a runes `$props()` declaration. An explicit annotation,
@@ -622,15 +632,24 @@ function recoverRunesProps(
     if (call?.type !== "CallExpression" || call.callee !== id) {
       continue;
     }
-    // A trailing `as`/`satisfies` cast carries the type, between call and declarator.
+    // Trailing `as`/`satisfies`/`!` operators sit between the call and the
+    // declarator and can be stacked. The outermost annotation is the effective
+    // type, so keep overwriting; `!` only unwraps.
     let valueNode: TSESTree.Expression = call;
     let castType: TSESTree.TypeNode | null = null;
-    if (
-      call.parent?.type === "TSAsExpression" ||
-      call.parent?.type === "TSSatisfiesExpression"
-    ) {
-      castType = call.parent.typeAnnotation;
-      valueNode = call.parent;
+    for (;;) {
+      const parent: TSESTree.Node | undefined = valueNode.parent;
+      if (
+        parent?.type === "TSAsExpression" ||
+        parent?.type === "TSSatisfiesExpression"
+      ) {
+        castType = parent.typeAnnotation;
+        valueNode = parent;
+      } else if (parent?.type === "TSNonNullExpression") {
+        valueNode = parent;
+      } else {
+        break;
+      }
     }
     if (
       valueNode.parent?.type !== "VariableDeclarator" ||
@@ -641,9 +660,8 @@ function recoverRunesProps(
     }
     if (castType) {
       return {
+        kind: "explicit",
         type: source.slice(castType.range[0], castType.range[1]),
-        probe: null,
-        open: false,
       };
     }
     const declId = valueNode.parent.id;
@@ -651,9 +669,8 @@ function recoverRunesProps(
     if (annotation) {
       const node = annotation.typeAnnotation;
       return {
+        kind: "explicit",
         type: source.slice(node.range[0], node.range[1]),
-        probe: null,
-        open: false,
       };
     }
     if (declId.type === "ObjectPattern") {
@@ -687,17 +704,19 @@ function inferPropsFromObjectPattern(
   const defaulted: string[] = [];
   let open = false;
   for (const prop of pattern.properties) {
-    if (prop.type !== "Property" || prop.computed) {
+    if (prop.type !== "Property") {
       open = true;
       continue;
     }
-    // String-literal keys are taken raw, so their quotes are preserved.
+    // Keys are taken raw so a string key keeps its quotes. A literal key is
+    // resolvable even when computed (`["a"]`), unlike an identifier one (`[k]`).
+    // Bigint keys are excluded: `0n` is not a valid type-literal key.
     let key: string;
-    if (prop.key.type === "Identifier") {
+    if (!prop.computed && prop.key.type === "Identifier") {
       key = prop.key.name;
     } else if (
       prop.key.type === "Literal" &&
-      typeof prop.key.value === "string"
+      (typeof prop.key.value === "string" || typeof prop.key.value === "number")
     ) {
       key = prop.key.raw;
     } else {
@@ -705,7 +724,7 @@ function inferPropsFromObjectPattern(
       continue;
     }
     if (prop.value.type === "AssignmentPattern") {
-      const def = prop.value.right;
+      const def = stripAsConst(prop.value.right);
       const degraded = degenerateDefaultType(def);
       if (degraded != null) {
         members.push(`${key}?: ${degraded}`);
@@ -719,10 +738,29 @@ function inferPropsFromObjectPattern(
     }
   }
   return {
-    type: members.length ? `{ ${members.join("; ")} }` : null,
+    kind: "inferred",
+    members: members.length ? `{ ${members.join("; ")} }` : null,
     probe: defaulted.length ? `{ ${defaulted.join(", ")} }` : null,
     open,
   };
+}
+
+/**
+ * Unwrap `X as const`, whose `const` parses as a type reference rather than a
+ * keyword. The frozen literal type it produces would reject every other value an
+ * importer passes; an author who wants that narrowing writes an explicit
+ * annotation, which takes precedence anyway.
+ */
+function stripAsConst(node: TSESTree.Expression): TSESTree.Expression {
+  if (
+    node.type === "TSAsExpression" &&
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  ) {
+    return node.expression;
+  }
+  return node;
 }
 
 /**

--- a/src/parser/typescript/restore.ts
+++ b/src/parser/typescript/restore.ts
@@ -197,9 +197,17 @@ function remapLocations(
     tokens.push(token);
   }
   result.ast.tokens = tokens;
-  for (const token of result.ast.comments || []) {
-    remapLocation(token);
+  // Virtual code can embed copies of user source (a `$props()` default, the
+  // props type text), so comments inside those copies must be dropped too.
+  const comments: TSESTree.Comment[] = [];
+  for (const comment of result.ast.comments || []) {
+    if (removeToken(comment)) {
+      continue;
+    }
+    remapLocation(comment);
+    comments.push(comment);
   }
+  result.ast.comments = comments;
 }
 
 /** Restore statement nodes */

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -29,8 +29,15 @@ interface TranslationEntry {
 interface TsLike {
   sys?: {
     readFile?: (path: string, encoding?: string) => string | undefined;
+    fileExists?: (path: string) => boolean;
   };
 }
+
+// TypeScript does not recognise the `.svelte` extension, so module resolution
+// falls back to appending `.ts` and probes `X.svelte.ts`. Serving the
+// component's virtual TypeScript there makes the import resolve to the real
+// prop types instead of Svelte's permissive ambient `declare module '*.svelte'`.
+const SVELTE_COMPANION_SUFFIX = ".svelte.ts";
 
 const translations = new Map<string, TranslationEntry>();
 const patchedSysObjects = new WeakSet();
@@ -41,6 +48,9 @@ let parserOptionsInspected = false;
 let patchAppliedCount = 0;
 let primeStoredCount = 0;
 let svelteReadFileCount = 0;
+// The collision warning sits in a hot resolution path, so it fires at most once
+// per process rather than once per file.
+let companionConflictWarned = false;
 
 function warn(msg: string): void {
   process.stderr.write(`[svelte-eslint-parser:ts-sys-hook] WARNING: ${msg}\n`);
@@ -115,6 +125,47 @@ function statMtimeMs(filePath: string): number | null {
   }
 }
 
+function realFileExists(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Virtual code of the `X.svelte` behind a probed `X.svelte.ts`, or `null` to fall through. */
+function translateCompanion(companionPath: string): string | null {
+  if (!companionPath.endsWith(SVELTE_COMPANION_SUFFIX)) return null;
+  const sveltePath = companionPath.slice(0, -".ts".length);
+  // A real runes module wins; never shadow it.
+  if (realFileExists(companionPath)) {
+    warnCompanionConflict(companionPath, sveltePath);
+    return null;
+  }
+  return translateOnDemand(sveltePath);
+}
+
+/**
+ * Only a real `X.svelte.ts` next to a real `X.svelte` costs the user anything:
+ * the guard above suppresses the virtual companion, so `./X.svelte` resolves to
+ * the runes module and the component's prop types stay unavailable.
+ */
+function warnCompanionConflict(
+  companionPath: string,
+  sveltePath: string,
+): void {
+  if (companionConflictWarned) return;
+  if (!realFileExists(sveltePath)) return;
+  companionConflictWarned = true;
+  warn(
+    `${sveltePath} and ${companionPath} both exist. TypeScript resolves ` +
+      `'./${path.basename(sveltePath)}' to the module, so component prop ` +
+      "types are not available for this component. The lint rule " +
+      "'svelte/no-conflicting-module-names' (eslint-plugin-svelte >= 3.22.0) " +
+      "reports this name collision.",
+  );
+}
+
 function readUtf8(filePath: string): string | null {
   try {
     return fs.readFileSync(filePath, "utf-8");
@@ -156,13 +207,39 @@ function patchTsSys(sys: TsLike["sys"]): void {
 
   const originalReadFile = sys.readFile.bind(sys);
   sys.readFile = (filePath: string, encoding?: string) => {
-    if (typeof filePath === "string" && filePath.endsWith(".svelte")) {
-      svelteReadFileCount++;
-      const virtual = translateOnDemand(filePath);
-      if (virtual !== null) return virtual;
+    if (typeof filePath === "string") {
+      // `X.svelte` is the component being linted; the `X.svelte.ts` companion is
+      // what module resolution probes for an imported component.
+      if (filePath.endsWith(".svelte")) {
+        svelteReadFileCount++;
+        const virtual = translateOnDemand(filePath);
+        if (virtual !== null) return virtual;
+      } else if (filePath.endsWith(SVELTE_COMPANION_SUFFIX)) {
+        const virtual = translateCompanion(filePath);
+        if (virtual !== null) {
+          svelteReadFileCount++;
+          return virtual;
+        }
+      }
     }
     return originalReadFile(filePath, encoding);
   };
+
+  // Claim the companion exists so module resolution reaches the `readFile`
+  // above; otherwise resolution fails and falls back to the ambient module.
+  if (typeof sys.fileExists === "function") {
+    const originalFileExists = sys.fileExists.bind(sys);
+    sys.fileExists = (filePath: string) => {
+      if (
+        typeof filePath === "string" &&
+        filePath.endsWith(SVELTE_COMPANION_SUFFIX) &&
+        translateCompanion(filePath) !== null
+      ) {
+        return true;
+      }
+      return originalFileExists(filePath);
+    };
+  }
 }
 
 /**
@@ -243,6 +320,8 @@ export function _resetTranslationCacheForTesting(): void {
   translations.clear();
   activeParserOptions = null;
   needsParseTimeRescan = false;
+  // Re-arm the once-per-process warning so tests don't depend on suite order.
+  companionConflictWarned = false;
 }
 
 /** Test seam: patch a caller-supplied `sys` instead of the require.cache ones. */

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 import { createRequire } from "module";
 import ts from "typescript";
+import { parseForESLint } from "../../src/index.js";
 import { normalizeParserOptions } from "../../src/parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "../../src/parser/svelte-to-virtual-ts.js";
 import { svelteVersion } from "../../src/parser/svelte-version.js";
@@ -67,6 +68,27 @@ function translate(source: string): string {
   });
   assert.notStrictEqual(result, null, "expected non-null translation");
   return result!;
+}
+
+function parseComponent(source: string): ReturnType<typeof parseForESLint> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ts-sys-hook-"));
+  const filePath = path.join(dir, "Component.svelte");
+  fs.writeFileSync(filePath, source, "utf-8");
+  try {
+    return parseForESLint(source, makeParserOptions(filePath));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function dumpComments(
+  result: ReturnType<typeof parseForESLint>,
+): (string | number)[][] {
+  return result.ast.comments.map((comment) => [
+    comment.type,
+    comment.value,
+    ...comment.range,
+  ]);
 }
 
 /**
@@ -286,11 +308,64 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
   let { value, count = 0 } = $props();
 </script>
 <p>{value}{count}</p>`);
-    assert.match(code, /const \$_propsProbe\d+ = \{ count: 0 \};/);
+    assert.match(code, /const \$_propsProbe\d+ = \{ count: \(0\) \};/);
     assert.match(
       code,
       /import\('svelte'\)\.Component<Partial<typeof \$_propsProbe\d+> & \{ value: any \}>;/,
     );
+  });
+
+  it("keeps a parenthesized default valid in the probe", () => {
+    const source = `<script lang="ts">
+  let { a = (1, 2) } = $props();
+</script>`;
+    assert.doesNotThrow(() => parseComponent(source));
+    const code = translate(source);
+    assert.match(code, /const \$_propsProbe\d+ = \{ a: \(1, 2\) \};/);
+    assert.match(
+      code,
+      /import\('svelte'\)\.Component<Partial<typeof \$_propsProbe\d+>>;/,
+    );
+  });
+
+  it("degrades defaults with no inhabitable inferred type to optional `any`", () => {
+    const code = translate(`<script lang="ts">
+  let { items = [], error = null, v = undefined, w = void 0 } = $props();
+</script>`);
+    assertComponentExport(
+      code,
+      `{ items?: any[]; error?: any; v?: any; w?: any }`,
+    );
+  });
+
+  it("still probes defaults that infer a usable type", () => {
+    const code = translate(`<script lang="ts">
+  let { list = [] as string[], one = [1], o = {} } = $props();
+</script>`);
+    assert.match(
+      code,
+      /const \$_propsProbe\d+ = \{ list: \(\[\] as string\[\]\), one: \(\[1\]\), o: \(\{\}\) \};/,
+    );
+  });
+
+  it("ignores a `<script module>` `$props()` in favor of the instance one", () => {
+    const code = translate(`<script module lang="ts">
+  const { moduleThing } = $props();
+</script>
+<script lang="ts">
+  let { realProp }: { realProp: string } = $props();
+</script>
+<p>{realProp}</p>`);
+    assertComponentExport(code, `{ realProp: string }`);
+  });
+
+  it("ignores a `$props()` nested inside a function", () => {
+    const code = translate(`<script lang="ts">
+  function f() { const { inner } = $props(); }
+  let { real } = $props();
+</script>
+<p>{real}</p>`);
+    assertComponentExport(code, `{ real: any }`);
   });
 
   it("references `generics` type parameters in the recovered props type", () => {
@@ -342,9 +417,11 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
   let { count = 0, [k]: v } = $props();
 </script>
 <p>{count}{v}</p>`);
+    const probe = /const (\$_propsProbe\d+) = /u.exec(code)?.[1];
+    assert.ok(probe, `expected a props probe in:\n${code}`);
     assertComponentExport(
       code,
-      `Partial<typeof $_propsProbe2> & Record<string, any>`,
+      `Partial<typeof ${probe}> & Record<string, any>`,
     );
   });
 
@@ -886,9 +963,49 @@ describeSvelte5(
     });
 
     it("accepts arbitrary extra props when a rest element is present", () => {
+      // Annotating the object is what exercises the open type: `mount()` infers
+      // its props from the argument, so it never rejects an extra property.
       const diagnostics = typeCheckConsumer(
         `<script lang="ts">\n  let { count = 0, ...rest } = $props();\n</script>`,
-        `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { count: 1, anything: "ok" } });`,
+        `const p: import("svelte").ComponentProps<typeof Foo> = { count: 1, anything: "ok" };\nvoid p;`,
+      );
+      assert.deepStrictEqual(
+        diagnostics.map((d) => d.code),
+        [],
+        `expected no diagnostics, got: ${diagnostics
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+          .join("; ")}`,
+      );
+    });
+
+    // A default whose inferred type is uninhabitable (`never[]`, `null`,
+    // `undefined`) would reject every value an importer can pass.
+    const DEGENERATE_DEFAULTS: { name: string; decl: string; value: string }[] =
+      [
+        { name: "empty array", decl: "items = []", value: '["a"]' },
+        { name: "null", decl: "items = null", value: "new Error()" },
+        { name: "undefined", decl: "items = undefined", value: "1" },
+      ];
+    for (const c of DEGENERATE_DEFAULTS) {
+      it(`lets importers pass any value for a degraded default (${c.name})`, () => {
+        const diagnostics = typeCheckConsumer(
+          `<script lang="ts">\n  let { ${c.decl} } = $props();\n</script>`,
+          `const ok: import("svelte").ComponentProps<typeof Foo>["items"] = ${c.value};\nvoid ok;`,
+        );
+        assert.deepStrictEqual(
+          diagnostics.map((d) => d.code),
+          [],
+          `expected ${c.value} to be accepted, got: ${diagnostics
+            .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+            .join("; ")}`,
+        );
+      });
+    }
+
+    it("does not let a `<script module>` `$props()` hijack the instance props", () => {
+      const diagnostics = typeCheckConsumer(
+        `<script module lang="ts">\n  const { moduleThing } = $props();\n</script>\n<script lang="ts">\n  let { realProp }: { realProp: string } = $props();\n</script>`,
+        `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { realProp: "hi" } });`,
       );
       assert.deepStrictEqual(
         diagnostics.map((d) => d.code),
@@ -1587,3 +1704,40 @@ describe("imported component prop types via real `.svelte` resolution (legacy, e
     );
   });
 });
+
+// The synthetic default export copies user source into the virtual code (a
+// `$props()` default, and the props type text twice), so comments inside those
+// copies must not survive restore as phantom entries.
+describeSvelte5(
+  "linted comments are unaffected by the synthetic export",
+  () => {
+    // A module-context default export suppresses the synthetic one without moving
+    // anything in the instance script.
+    const SUPPRESS = `\n<script module lang="ts">\n  export default 0;\n</script>`;
+    const CASES: { name: string; source: string }[] = [
+      {
+        name: "a line comment in a default",
+        source: `<script lang="ts">\n  let { a = [\n    // note\n    1,\n  ] } = $props();\n</script>`,
+      },
+      {
+        name: "a block comment in a default",
+        source: `<script lang="ts">\n  let { a = [/* note */ 1] } = $props();\n</script>`,
+      },
+      {
+        name: "a comment in a `$props()` type annotation",
+        source: `<script lang="ts">\n  let { a }: { /* note */ a: string } = $props();\n</script>`,
+      },
+    ];
+    for (const c of CASES) {
+      it(`keeps \`ast.comments\` identical for ${c.name}`, () => {
+        const withExport = parseComponent(c.source);
+        const withoutExport = parseComponent(c.source + SUPPRESS);
+        assert.deepStrictEqual(
+          dumpComments(withExport),
+          dumpComments(withoutExport),
+        );
+        assert.strictEqual(withExport.ast.comments.length, 1);
+      });
+    }
+  },
+);

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -512,6 +512,50 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
     assertComponentExport(code, `{ name: any } & Record<string, any>`);
   });
 
+  // A prop destructured twice would emit the key twice, a TS2300 duplicate
+  // identifier on the producer side. The first occurrence wins.
+  it("emits a doubly-destructured prop only once", () => {
+    const code = translate(`<script lang="ts">
+  let { a, a: b } = $props();
+</script>
+<p>{a}{b}</p>`);
+    assertComponentExport(code, `{ a: any }`);
+  });
+
+  it("deduplicates a string-literal key against its identifier form", () => {
+    const code = translate(`<script lang="ts">
+  let { "a": x, a: y } = $props();
+</script>
+<p>{x}{y}</p>`);
+    assertComponentExport(code, `{ "a": any }`);
+  });
+
+  it("deduplicates numeric keys that name the same property", () => {
+    const code = translate(`<script lang="ts">
+  let { 1e3: p, 1_000: q } = $props();
+</script>
+<p>{p}{q}</p>`);
+    assertComponentExport(code, `{ 1e3: any }`);
+  });
+
+  it("deduplicates across the required and defaulted buckets", () => {
+    const code = translate(`<script lang="ts">
+  let { a = 0, a: b } = $props();
+</script>
+<p>{a}{b}</p>`);
+    const probe = /const (\$_propsProbe\d+) = /u.exec(code)?.[1];
+    assert.ok(probe, `expected a props probe in:\n${code}`);
+    assertComponentExport(code, `Partial<typeof ${probe}>`);
+  });
+
+  it("keeps distinct numeric and string keys apart", () => {
+    const code = translate(`<script lang="ts">
+  let { 0: x, "1": y } = $props();
+</script>
+<p>{x}{y}</p>`);
+    assertComponentExport(code, `{ 0: any; "1": any }`);
+  });
+
   it("accepts no props at all for an empty destructuring", () => {
     const code = translate(`<script lang="ts">
   let {} = $props();

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -328,9 +328,6 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
     assertComponentExport(code, `{ v: string }`);
   });
 
-  // A rest element only means the prop set is open, so the props that *can* be
-  // read are still enumerated and the type is opened with an index signature.
-  // This mirrors svelte2tsx.
   it("keeps enumerated props and opens the type for a rest element", () => {
     const code = translate(`<script lang="ts">
   let { value, ...rest } = $props();
@@ -868,8 +865,6 @@ describeSvelte5(
       });
     }
 
-    // A rest element used to discard every prop and fall back to
-    // `Record<string, any>`, so importers lost the defaults too.
     it("still resolves defaults alongside a rest element", () => {
       const component = `<script lang="ts">\n  let { count = 0, ...rest } = $props();\n</script>`;
       const t = `import("svelte").ComponentProps<typeof Foo>["count"]`;
@@ -890,7 +885,6 @@ describeSvelte5(
       );
     });
 
-    // The index signature from the rest element keeps unknown props allowed.
     it("accepts arbitrary extra props when a rest element is present", () => {
       const diagnostics = typeCheckConsumer(
         `<script lang="ts">\n  let { count = 0, ...rest } = $props();\n</script>`,

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -328,12 +328,35 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
     assertComponentExport(code, `{ v: string }`);
   });
 
-  it("falls back to a permissive props type for an un-annotated `$props()` with a rest element", () => {
+  // A rest element only means the prop set is open, so the props that *can* be
+  // read are still enumerated and the type is opened with an index signature.
+  // This mirrors svelte2tsx.
+  it("keeps enumerated props and opens the type for a rest element", () => {
     const code = translate(`<script lang="ts">
   let { value, ...rest } = $props();
 </script>
 <p>{value}</p>`);
-    assertComponentExport(code, `Record<string, any>`);
+    assertComponentExport(code, `{ value: any } & Record<string, any>`);
+  });
+
+  it("opens the type for a computed key without discarding the other props", () => {
+    const code = translate(`<script lang="ts">
+  const k = "a";
+  let { count = 0, [k]: v } = $props();
+</script>
+<p>{count}{v}</p>`);
+    assertComponentExport(
+      code,
+      `Partial<typeof $_propsProbe2> & Record<string, any>`,
+    );
+  });
+
+  it("accepts no props at all for an empty destructuring", () => {
+    const code = translate(`<script lang="ts">
+  let {} = $props();
+</script>
+<p>hi</p>`);
+    assertComponentExport(code, `Record<string, never>`);
   });
 
   it("falls back to a permissive props type when there is no recoverable `$props()`", () => {
@@ -844,6 +867,43 @@ describeSvelte5(
         );
       });
     }
+
+    // A rest element used to discard every prop and fall back to
+    // `Record<string, any>`, so importers lost the defaults too.
+    it("still resolves defaults alongside a rest element", () => {
+      const component = `<script lang="ts">\n  let { count = 0, ...rest } = $props();\n</script>`;
+      const t = `import("svelte").ComponentProps<typeof Foo>["count"]`;
+      const good = typeCheckConsumer(component, `const ok: ${t} = 5;`);
+      assert.deepStrictEqual(
+        good.map((d) => d.code),
+        [],
+        `expected 5 to be accepted, got: ${good
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+          .join("; ")}`,
+      );
+      const bad = typeCheckConsumer(component, `const ng: ${t} = "x";`);
+      assert.ok(
+        bad.some((d) => d.code === 2322),
+        `expected "x" to be rejected (TS2322), got: ${bad
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+
+    // The index signature from the rest element keeps unknown props allowed.
+    it("accepts arbitrary extra props when a rest element is present", () => {
+      const diagnostics = typeCheckConsumer(
+        `<script lang="ts">\n  let { count = 0, ...rest } = $props();\n</script>`,
+        `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { count: 1, anything: "ok" } });`,
+      );
+      assert.deepStrictEqual(
+        diagnostics.map((d) => d.code),
+        [],
+        `expected no diagnostics, got: ${diagnostics
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+          .join("; ")}`,
+      );
+    });
 
     it("works with Svelte 5 `mount(Foo, ...)` value usage and checks props", () => {
       const diagnostics = typeCheckConsumer(

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -348,6 +348,23 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
     );
   });
 
+  it("widens an `as const` default so importers can pass other values", () => {
+    const code = translate(`<script lang="ts">
+  let { xs = [1, 2] as const, mode = "dark" as const } = $props();
+</script>`);
+    assert.match(
+      code,
+      /const \$_propsProbe\d+ = \{ xs: \(\[1, 2\]\), mode: \("dark"\) \};/,
+    );
+  });
+
+  it("degrades an `as const` empty array default like a bare one", () => {
+    const code = translate(`<script lang="ts">
+  let { xs = [] as const } = $props();
+</script>`);
+    assertComponentExport(code, `{ xs?: any[] }`);
+  });
+
   it("ignores a `<script module>` `$props()` in favor of the instance one", () => {
     const code = translate(`<script module lang="ts">
   const { moduleThing } = $props();
@@ -395,6 +412,44 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
     assertComponentExport(code, `Props`);
   });
 
+  it("recovers the outermost type from stacked `as` casts", () => {
+    const code = translate(`<script lang="ts">
+  interface Inner { v: string }
+  interface Outer { v: string }
+  let p = $props() as Inner as Outer;
+</script>
+<p>{p.v}</p>`);
+    assertComponentExport(code, `Outer`);
+  });
+
+  it("recovers the outermost type from a `satisfies` followed by an `as`", () => {
+    const code = translate(`<script lang="ts">
+  interface Inner { v: string }
+  interface Outer { v: string }
+  let p = $props() satisfies Inner as Outer;
+</script>
+<p>{p.v}</p>`);
+    assertComponentExport(code, `Outer`);
+  });
+
+  it("looks through a non-null assertion to the declared annotation", () => {
+    const code = translate(`<script lang="ts">
+  interface Props { v: string }
+  let p: Props = $props()!;
+</script>
+<p>{p.v}</p>`);
+    assertComponentExport(code, `Props`);
+  });
+
+  it("looks through a non-null assertion to a following `as` cast", () => {
+    const code = translate(`<script lang="ts">
+  interface Props { v: string }
+  let p = $props()! as Props;
+</script>
+<p>{p.v}</p>`);
+    assertComponentExport(code, `Props`);
+  });
+
   it("is not swallowed by a trailing line comment with no following newline", () => {
     const code = translate(
       `<script lang="ts">let { v }: { v: string } = $props() // trailing</script>`,
@@ -423,6 +478,38 @@ describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
       code,
       `Partial<typeof ${probe}> & Record<string, any>`,
     );
+  });
+
+  it("resolves a computed key that is a string literal", () => {
+    const code = translate(`<script lang="ts">
+  let { ["a"]: a, b } = $props();
+</script>
+<p>{a}{b}</p>`);
+    assertComponentExport(code, `{ "a": any; b: any }`);
+  });
+
+  it("resolves a computed key that is a numeric literal", () => {
+    const code = translate(`<script lang="ts">
+  let { [0]: zero } = $props();
+</script>
+<p>{zero}</p>`);
+    assertComponentExport(code, `{ 0: any }`);
+  });
+
+  it("keeps a numeric-literal key without opening the whole prop set", () => {
+    const code = translate(`<script lang="ts">
+  let { 0: zero, name } = $props();
+</script>
+<p>{zero}{name}</p>`);
+    assertComponentExport(code, `{ 0: any; name: any }`);
+  });
+
+  it("opens the type for a bigint key, which no type literal can name", () => {
+    const code = translate(`<script lang="ts">
+  let { 0n: big, name } = $props();
+</script>
+<p>{big}{name}</p>`);
+    assertComponentExport(code, `{ name: any } & Record<string, any>`);
   });
 
   it("accepts no props at all for an empty destructuring", () => {
@@ -991,6 +1078,29 @@ describeSvelte5(
         const diagnostics = typeCheckConsumer(
           `<script lang="ts">\n  let { ${c.decl} } = $props();\n</script>`,
           `const ok: import("svelte").ComponentProps<typeof Foo>["items"] = ${c.value};\nvoid ok;`,
+        );
+        assert.deepStrictEqual(
+          diagnostics.map((d) => d.code),
+          [],
+          `expected ${c.value} to be accepted, got: ${diagnostics
+            .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+            .join("; ")}`,
+        );
+      });
+    }
+
+    // `as const` would freeze the default into a narrow literal type, so an
+    // importer passing any other value of the same shape would be rejected.
+    const AS_CONST_DEFAULTS: { name: string; decl: string; value: string }[] = [
+      { name: "tuple", decl: "xs = [1, 2] as const", value: "[3, 4]" },
+      { name: "string", decl: 'mode = "dark" as const', value: '"light"' },
+    ];
+    for (const c of AS_CONST_DEFAULTS) {
+      it(`lets importers pass another value for an \`as const\` default (${c.name})`, () => {
+        const prop = c.decl.slice(0, c.decl.indexOf(" "));
+        const diagnostics = typeCheckConsumer(
+          `<script lang="ts">\n  let { ${c.decl} } = $props();\n</script>`,
+          `const ok: import("svelte").ComponentProps<typeof Foo>["${prop}"] = ${c.value};\nvoid ok;`,
         );
         assert.deepStrictEqual(
           diagnostics.map((d) => d.code),
@@ -1741,3 +1851,35 @@ describeSvelte5(
     }
   },
 );
+
+// The probe const is virtual-only, and a default referencing a local makes it
+// read that local. Restore must drop both the probe's own variable and the read
+// it appended, neither of which shows up in the AST body.
+describeSvelte5("the props probe leaves no trace in the scope manager", () => {
+  const SOURCE = `<script lang="ts">\n  const base = { a: 1 };\n  let { conf = base } = $props();\n</script>`;
+
+  it("declares no `$_propsProbe` variable in any scope", () => {
+    const { scopeManager } = parseComponent(SOURCE);
+    const leaked = scopeManager.scopes
+      .flatMap((scope) => scope.variables)
+      .map((variable) => variable.name)
+      .filter((name) => /^\$_propsProbe\d+$/u.test(name));
+    assert.deepStrictEqual(leaked, []);
+  });
+
+  it("appends no dangling reference to the user variable the default reads", () => {
+    const { scopeManager } = parseComponent(SOURCE);
+    const base = scopeManager.scopes
+      .flatMap((scope) => scope.variables)
+      .find((variable) => variable.name === "base");
+    assert.ok(base, "expected a `base` variable");
+    for (const reference of base.references) {
+      const [start, end] = reference.identifier.range!;
+      assert.strictEqual(
+        SOURCE.slice(start, end),
+        "base",
+        `reference at ${start}-${end} does not span the real \`base\` identifier`,
+      );
+    }
+  });
+});

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -2,13 +2,23 @@ import assert from "assert";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { createRequire } from "module";
+import ts from "typescript";
 import { normalizeParserOptions } from "../../src/parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "../../src/parser/svelte-to-virtual-ts.js";
+import { svelteVersion } from "../../src/parser/svelte-version.js";
 import {
   _patchTsSysForTesting,
   _resetTranslationCacheForTesting,
   rememberParserOptions,
 } from "../../src/ts-sys-hook.js";
+
+// Runes-specific suites are Svelte 5 only; the legacy suites run on every
+// version in the test matrix, with version-aware assertions.
+const describeSvelte5 = svelteVersion.gte(5) ? describe : describe.skip;
+// In Svelte 5 the exported value is the non-constructable `Component` function
+// type, so `new Foo(...)` only applies to the legacy class component.
+const describeLegacyClass = svelteVersion.gte(5) ? describe.skip : describe;
 
 const TS_SCRIPT = `<script lang="ts">
   let count: number = 0;
@@ -44,6 +54,95 @@ function makeParserOptions(filePath: string) {
     ecmaVersion: 2024,
     sourceType: "module",
   });
+}
+
+function translate(source: string): string {
+  let result: string | null = null;
+  withTempSvelteFile(source, (filePath) => {
+    result = svelteToVirtualTypeScript(
+      filePath,
+      source,
+      makeParserOptions(filePath),
+    );
+  });
+  assert.notStrictEqual(result, null, "expected non-null translation");
+  return result!;
+}
+
+/**
+ * Run `body` with the hook's stderr warnings intercepted rather than printed, so
+ * tests that deliberately create a collision don't leak the warning into a
+ * normal test run's output. Non-hook writes pass through untouched.
+ */
+function interceptHookWarnings<T>(body: () => T): {
+  result: T;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: unknown, ...rest: unknown[]) => {
+    if (typeof chunk === "string" && chunk.includes("ts-sys-hook")) {
+      warnings.push(chunk);
+      return true;
+    }
+    return (original as (...a: unknown[]) => boolean)(chunk, ...rest);
+  }) as typeof process.stderr.write;
+  try {
+    return { result: body(), warnings };
+  } finally {
+    process.stderr.write = original;
+  }
+}
+
+/** Collect the hook's stderr warnings while `body` runs. */
+function captureWarnings(body: () => void): string[] {
+  return interceptHookWarnings(body).warnings;
+}
+
+/** Run `body`, swallowing hook warnings the test is not asserting on. */
+function withoutHookWarnings<T>(body: () => T): T {
+  return interceptHookWarnings(body).result;
+}
+
+/** Mirrors `componentTypeText` in the parser. */
+function expectedComponentTypeText(
+  props: string,
+  events = "Record<string, any>",
+  slots = "Record<string, any>",
+): { value: string; type: string } {
+  const typeArgs = `<${props}, ${events}, ${slots}>`;
+  if (svelteVersion.gte(5)) {
+    return {
+      value: `import('svelte').Component<${props}>`,
+      type: `import('svelte').SvelteComponent${typeArgs}`,
+    };
+  }
+  const cls = svelteVersion.gte(4) ? "SvelteComponent" : "SvelteComponentTyped";
+  const inst = `import('svelte').${cls}${typeArgs}`;
+  return {
+    value: `new (options: import('svelte').ComponentConstructorOptions<${props}>) => ${inst}`,
+    type: inst,
+  };
+}
+
+/** Assert the emitted virtual code carries the expected value/type default export. */
+function assertComponentExport(
+  code: string,
+  props: string,
+  events = "Record<string, any>",
+  slots = "Record<string, any>",
+): void {
+  const { value, type } = expectedComponentTypeText(props, events, slots);
+  assert.ok(
+    code.includes(`: ${value};`),
+    `expected value-side type \`${value}\` in:\n${code}`,
+  );
+  assert.ok(
+    code.includes(`= ${type};`),
+    `expected type-side \`${type}\` in:\n${code}`,
+  );
+  assert.match(code, /declare const \$_svelteComponent\d+:/);
+  assert.match(code, /export \{ \$_svelteComponent\d+ as default \};/);
 }
 
 describe("svelteToVirtualTypeScript", () => {
@@ -160,5 +259,1277 @@ describe("ts.sys.readFile hook wiring", () => {
 
       assert.strictEqual(sys.readFile(filePath), TS_SCRIPT);
     });
+  });
+});
+
+describeSvelte5("synthetic component default export (runes, Svelte 5)", () => {
+  it("recovers the props type from an annotated `$props()` declaration", () => {
+    const code = translate(`<script lang="ts">
+  let { value, count = 0 }: { value: string; count?: number } = $props();
+</script>
+<p>{value}{count}</p>`);
+    assertComponentExport(code, `{ value: string; count?: number }`);
+  });
+
+  it("references a named props interface as-is", () => {
+    const code = translate(`<script lang="ts">
+  interface Props { a: number; b?: string }
+  let props: Props = $props();
+</script>
+<p>{props.a}</p>`);
+    assertComponentExport(code, `Props`);
+  });
+
+  it("infers an un-annotated `$props()` via a `typeof` probe of the defaults", () => {
+    // Required props are `any`; defaulted props get their type from the probe.
+    const code = translate(`<script lang="ts">
+  let { value, count = 0 } = $props();
+</script>
+<p>{value}{count}</p>`);
+    assert.match(code, /const \$_propsProbe\d+ = \{ count: 0 \};/);
+    assert.match(
+      code,
+      /import\('svelte'\)\.Component<Partial<typeof \$_propsProbe\d+> & \{ value: any \}>;/,
+    );
+  });
+
+  it("references `generics` type parameters in the recovered props type", () => {
+    const code = translate(`<script lang="ts" generics="T">
+  let { items, selected }: { items: T[]; selected: T } = $props();
+</script>
+<p>{selected}</p>`);
+    assert.match(code, /type T = unknown;/);
+    assertComponentExport(code, `{ items: T[]; selected: T }`);
+  });
+
+  it("recovers the props type from a `$props() as Props` cast", () => {
+    const code = translate(`<script lang="ts">
+  interface Props { v: string }
+  let p = $props() as Props;
+</script>
+<p>{p.v}</p>`);
+    assertComponentExport(code, `Props`);
+  });
+
+  it("recovers the props type from a `$props() satisfies Props` expression", () => {
+    const code = translate(`<script lang="ts">
+  interface Props { v: string }
+  let p = $props() satisfies Props;
+</script>
+<p>{p.v}</p>`);
+    assertComponentExport(code, `Props`);
+  });
+
+  it("is not swallowed by a trailing line comment with no following newline", () => {
+    const code = translate(
+      `<script lang="ts">let { v }: { v: string } = $props() // trailing</script>`,
+    );
+    assert.match(code, /\ndeclare const \$_svelteComponent\d+:/);
+    assertComponentExport(code, `{ v: string }`);
+  });
+
+  it("falls back to a permissive props type for an un-annotated `$props()` with a rest element", () => {
+    const code = translate(`<script lang="ts">
+  let { value, ...rest } = $props();
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `Record<string, any>`);
+  });
+
+  it("falls back to a permissive props type when there is no recoverable `$props()`", () => {
+    const code = translate(`<script lang="ts">
+  let count = $state(0);
+</script>
+<p>{count}</p>`);
+    assertComponentExport(code, `Record<string, any>`);
+  });
+
+  it("exposes the default export as both a value and a type", () => {
+    // The export must carry both meanings: `ComponentProps<typeof Foo>` needs
+    // the value, `ComponentEvents<Foo>` needs the type.
+    const code = translate(`<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`);
+    assert.match(code, /declare const \$_svelteComponent\d+:/);
+    assert.match(code, /type \$_svelteComponent\d+ = /);
+    assert.match(code, /export \{ \$_svelteComponent\d+ as default \};/);
+  });
+
+  it("types the exported value as the Svelte 5 `Component` (for `typeof Foo`)", () => {
+    const code = translate(`<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`);
+    assert.match(
+      code,
+      /declare const \$_svelteComponent\d+: import\('svelte'\)\.Component<\{ value: string \}>;/,
+    );
+    assert.match(
+      code,
+      /type \$_svelteComponent\d+ = import\('svelte'\)\.SvelteComponent</,
+    );
+  });
+
+  it("does not emit a default export when the user already has one", () => {
+    const code = translate(`<script lang="ts" module>
+  export default 42;
+</script>
+<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`);
+    assert.doesNotMatch(code, /export \{ \$_svelteComponent\d+ as default \};/);
+    assert.match(code, /export default 42/);
+  });
+
+  it("does not emit a default export when the user has `export { x as default }`", () => {
+    const code = translate(`<script lang="ts" module>
+  const x = 42;
+  export { x as default };
+</script>
+<script lang="ts">
+  let { value }: { value: string } = $props();
+</script>
+<p>{value}</p>`);
+    assert.doesNotMatch(code, /export \{ \$_svelteComponent\d+ as default \};/);
+  });
+});
+
+describe("synthetic component default export (legacy, all versions)", () => {
+  it("synthesizes props from legacy `export let` declarations", () => {
+    const code = translate(`<script lang="ts">
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`);
+    assertComponentExport(code, `{ value: string; count?: typeof count }`);
+  });
+
+  it("marks `export let` props with a default value as optional", () => {
+    const code = translate(`<script lang="ts">
+  export let value: string = "x";
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value?: string }`);
+  });
+
+  it("uses a legacy `$$Props` interface, taking priority over `export let`", () => {
+    const code = translate(`<script lang="ts">
+  interface $$Props { value: string; count?: number }
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`);
+    assertComponentExport(code, `$$Props`);
+  });
+
+  it("uses a legacy `$$Props` type alias", () => {
+    const code = translate(`<script lang="ts">
+  type $$Props = { a: number };
+  export let a: number;
+</script>
+<p>{a}</p>`);
+    assertComponentExport(code, `$$Props`);
+  });
+
+  it("wires legacy `$$Events` and `$$Slots` into the component type", () => {
+    const code = translate(`<script lang="ts">
+  interface $$Props { value: string }
+  interface $$Events { foo: CustomEvent<number> }
+  interface $$Slots { default: {} }
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `$$Props`, `$$Events`, `$$Slots`);
+  });
+
+  it("falls back to a permissive props type when none can be recovered", () => {
+    const code = translate(`<script lang="ts">
+  let value = 1;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `Record<string, any>`);
+  });
+
+  // Renamed exports of a top-level `let` are props too.
+  it("treats `export { className as class }` as a `class` prop", () => {
+    const code = translate(`<script lang="ts">
+  let className: string = "";
+  export { className as class };
+</script>
+<div class={className}></div>`);
+    assertComponentExport(code, `{ class?: string }`);
+  });
+
+  it("treats a renamed `export { foo as bar }` of a top-level `let` as a prop", () => {
+    const code = translate(`<script lang="ts">
+  let foo: number;
+  export { foo as bar };
+</script>
+<p>{foo}</p>`);
+    // The local's annotation is used as-is, mirroring the `export let` path.
+    assertComponentExport(code, `{ bar: number }`);
+  });
+
+  it("infers a renamed export's type via `typeof` when the local is un-annotated", () => {
+    const code = translate(`<script lang="ts">
+  let foo = 0;
+  export { foo as bar };
+</script>
+<p>{foo}</p>`);
+    assertComponentExport(code, `{ bar?: typeof foo }`);
+  });
+
+  it("ignores a renamed export whose local is not a top-level `let`", () => {
+    const code = translate(`<script lang="ts">
+  function helper() {}
+  export { helper as onClick };
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  // Instance/module boundary: `result.ast.body` concatenates both scripts, so a
+  // module-context declaration must not leak into the instance component type.
+  it("does not treat a module-script `export let` as a prop", () => {
+    const code = translate(`<script lang="ts" context="module">
+  export let shared = 1;
+</script>
+<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  it("ignores a `$$Props` declared in the module script", () => {
+    const code = translate(`<script lang="ts" context="module">
+  interface $$Props { fromModule: number }
+</script>
+<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    // The module `$$Props` is ignored, so the instance `export let` synthesis wins.
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  it("ignores `$$Events`/`$$Slots` declared in the module script", () => {
+    const code = translate(`<script lang="ts" context="module">
+  interface $$Events { foo: CustomEvent<number> }
+  interface $$Slots { default: {} }
+</script>
+<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    // Module-declared `$$Events`/`$$Slots` are not honored; events/slots stay permissive.
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  // `type` is not a script-context attribute, so `<script type="module">` is an
+  // instance script. Only `context="module"` (and Svelte 5's `module`) make one.
+  it('treats a lone `<script type="module">` as the instance script', () => {
+    const code = translate(`<script type="module" lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  it('does not leak a module-script `export let` into a `<script type="module">` instance', () => {
+    const code = translate(`<script context="module" lang="ts">
+  export let shared = 1;
+</script>
+<script type="module" lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  it('ignores a module-script `$$Props` when the instance is `<script type="module">`', () => {
+    const code = translate(`<script context="module" lang="ts">
+  interface $$Props { fromModule: number }
+</script>
+<script type="module" lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string }`);
+  });
+
+  // Open props: a component reading `$$props`/`$$restProps` accepts arbitrary
+  // attributes, so the synthesized (closed) props type is opened.
+  it("opens the synthesized props type when `$$restProps` is referenced", () => {
+    const code = translate(`<script lang="ts">
+  export let value: string;
+  $$restProps;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string } & { [key: string]: any }`);
+  });
+
+  it("opens the synthesized props type when `$$props` is referenced", () => {
+    const code = translate(`<script lang="ts">
+  export let value: string;
+  const all = $$props;
+</script>
+<p>{value}{all}</p>`);
+    assertComponentExport(code, `{ value: string } & { [key: string]: any }`);
+  });
+
+  it("keeps an authored `$$Props` type authoritative even with `$$restProps`", () => {
+    const code = translate(`<script lang="ts">
+  interface $$Props { value: string }
+  export let value: string;
+  $$restProps;
+</script>
+<p>{value}</p>`);
+    // `$$Props` is used as-is (the user owns the open/closed decision there).
+    assertComponentExport(code, `$$Props`);
+  });
+
+  // Version-agnostic guards, exercised with legacy `export let` components.
+  it("is not swallowed by a trailing line comment with no following newline", () => {
+    const code = translate(
+      `<script lang="ts">export let v: string // trailing</script>`,
+    );
+    assert.match(code, /\ndeclare const \$_svelteComponent\d+:/);
+    assertComponentExport(code, `{ v: string }`);
+  });
+
+  it("does not emit a default export when the user already has one", () => {
+    const code = translate(`<script lang="ts" context="module">
+  export default 42;
+</script>
+<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assert.doesNotMatch(code, /export \{ \$_svelteComponent\d+ as default \};/);
+    assert.match(code, /export default 42/);
+  });
+
+  it("does not emit a default export when the user has `export { x as default }`", () => {
+    const code = translate(`<script lang="ts" context="module">
+  const x = 42;
+  export { x as default };
+</script>
+<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assert.doesNotMatch(code, /export \{ \$_svelteComponent\d+ as default \};/);
+  });
+});
+
+// The `<script module>` shorthand is Svelte 5 only; the `context="module"`
+// equivalents live in the all-versions suite above.
+describeSvelte5("instance/module boundary with `<script module>`", () => {
+  it('does not leak a `<script module>` `export let` into a `<script type="module">` instance', () => {
+    const code = translate(`<script module lang="ts">
+  export let shared = 1;
+</script>
+<script type="module" lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`);
+    assertComponentExport(code, `{ value: string }`);
+  });
+});
+
+// The end-to-end suites type-check a consumer `.ts` against the virtual code
+// produced for a `.svelte` component: the importer experience.
+const require2 = createRequire(import.meta.url);
+const sveltePackageJson = require2("svelte/package.json");
+// Svelte 3 ships its runtime types at `types/runtime/index.d.ts`, Svelte 4/5 at
+// `types/index.d.ts`; read the location from the package's `types` field.
+const svelteTypesPath = path.join(
+  path.dirname(require2.resolve("svelte/package.json")),
+  sveltePackageJson.types ??
+    sveltePackageJson.exports?.["."]?.types ??
+    "types/index.d.ts",
+);
+// Fail loudly if that path rots, instead of silently type-checking the e2e
+// consumers against a missing `svelte` module.
+assert.ok(
+  fs.existsSync(svelteTypesPath),
+  `resolved svelte types path does not exist: ${svelteTypesPath}`,
+);
+
+// Diagnostic codes meaning the synthetic export itself is structurally broken:
+// a missing module, an unresolved name, or a non-existent Svelte helper type.
+// These must never appear on the producer file, or importers silently
+// type-check against `any`.
+const PRODUCER_STRUCTURAL_CODES = new Set([2304, 2307, 2503, 2551, 2552, 2694]);
+
+/**
+ * Type-check a consumer `.ts` against the virtual code produced for a `.svelte`
+ * component. Only the consumer's diagnostics are returned, since the producer
+ * has pre-existing ones of its own, but the producer is still asserted free of
+ * `PRODUCER_STRUCTURAL_CODES` so its rot can't pass behind a clean consumer.
+ */
+function typeCheckConsumer(
+  componentSource: string,
+  consumerBody: string,
+): ts.Diagnostic[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "component-export-"));
+  try {
+    const componentVirtual = svelteToVirtualTypeScript(
+      path.join(dir, "Foo.svelte"),
+      componentSource,
+      makeParserOptions(path.join(dir, "Foo.svelte")),
+    );
+    assert.notStrictEqual(componentVirtual, null);
+    fs.writeFileSync(path.join(dir, "Foo.ts"), componentVirtual!, "utf-8");
+    fs.writeFileSync(
+      path.join(dir, "Bar.ts"),
+      `import Foo from "./Foo";\n${consumerBody}\n`,
+      "utf-8",
+    );
+
+    const program = ts.createProgram(
+      [path.join(dir, "Foo.ts"), path.join(dir, "Bar.ts")],
+      {
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        types: [],
+        baseUrl: dir,
+        paths: { svelte: [svelteTypesPath] },
+      },
+    );
+    const barPath = path.join(dir, "Bar.ts");
+    const fooPath = path.join(dir, "Foo.ts");
+    const all = [
+      ...program.getSemanticDiagnostics(),
+      ...program.getSyntacticDiagnostics(),
+    ];
+    const producerStructural = all.filter(
+      (d) =>
+        d.file?.fileName === fooPath && PRODUCER_STRUCTURAL_CODES.has(d.code),
+    );
+    assert.deepStrictEqual(
+      producerStructural.map((d) => d.code),
+      [],
+      `producer Foo.ts has structural diagnostics: ${producerStructural
+        .map(
+          (d) =>
+            `TS${d.code} ${ts.flattenDiagnosticMessageText(d.messageText, " ")}`,
+        )
+        .join("; ")}`,
+    );
+    return all.filter((d) => d.file?.fileName === barPath);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describeSvelte5(
+  "imported component prop types, runes (end-to-end type check)",
+  () => {
+    const COMPONENT = `<script lang="ts">
+  let { value, count = 0 }: { value: string; count?: number } = $props();
+</script>
+<p>{value}{count}</p>`;
+
+    it("resolves a prop to its declared type for importers", () => {
+      const diagnostics = typeCheckConsumer(
+        COMPONENT,
+        `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123;`,
+      );
+      // `value` is `string`, so assigning a number must be a type error.
+      assert.ok(
+        diagnostics.some((d) => d.code === 2322),
+        `expected TS2322 (number not assignable to string), got: ${diagnostics
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+
+    it("accepts correctly typed prop values from importers", () => {
+      const diagnostics = typeCheckConsumer(
+        COMPONENT,
+        `const value: import("svelte").ComponentProps<typeof Foo>["value"] = "hello";\nconst count: import("svelte").ComponentProps<typeof Foo>["count"] = 5;\nvoid value; void count;`,
+      );
+      assert.deepStrictEqual(
+        diagnostics.map((d) => d.code),
+        [],
+        `expected no diagnostics, got: ${diagnostics
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+          .join("; ")}`,
+      );
+    });
+
+    // The `typeof` probe lets TS infer arbitrary default types, not just literals.
+    // Each case checks the importer-side resolved type via a good + bad assignment.
+    const INFERRED_DEFAULTS: {
+      name: string;
+      prop: string;
+      decl: string;
+      good: string;
+      bad: string;
+    }[] = [
+      {
+        name: "number literal",
+        prop: "n",
+        decl: "n = 0",
+        good: "1",
+        bad: '"x"',
+      },
+      {
+        name: "negative number",
+        prop: "n",
+        decl: "n = -1",
+        good: "-2",
+        bad: '"x"',
+      },
+      { name: "string", prop: "s", decl: 's = "x"', good: '"y"', bad: "1" },
+      { name: "boolean", prop: "b", decl: "b = false", good: "true", bad: "1" },
+      {
+        name: "array",
+        prop: "a",
+        decl: "a = [1, 2]",
+        good: "[3]",
+        bad: '["x"]',
+      },
+      {
+        name: "object",
+        prop: "o",
+        decl: "o = { x: 1 }",
+        good: "{ x: 2 }",
+        bad: '{ x: "s" }',
+      },
+      {
+        name: "$bindable(literal)",
+        prop: "v",
+        decl: "v = $bindable(0)",
+        good: "5",
+        bad: '"x"',
+      },
+      {
+        name: "string-literal key",
+        prop: "data-id",
+        decl: '"data-id": id = 1',
+        good: "2",
+        bad: '"x"',
+      },
+    ];
+    for (const c of INFERRED_DEFAULTS) {
+      it(`infers and enforces an un-annotated default (${c.name})`, () => {
+        const component = `<script lang="ts">\n  let { ${c.decl} } = $props();\n</script>`;
+        const t = `import("svelte").ComponentProps<typeof Foo>[${JSON.stringify(c.prop)}]`;
+        const good = typeCheckConsumer(
+          component,
+          `const ok: ${t} = ${c.good};`,
+        );
+        assert.deepStrictEqual(
+          good.map((d) => d.code),
+          [],
+          `expected ${c.good} to be accepted, got: ${good
+            .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+            .join("; ")}`,
+        );
+        const bad = typeCheckConsumer(component, `const ng: ${t} = ${c.bad};`);
+        assert.ok(
+          bad.some((d) => d.code === 2322),
+          `expected ${c.bad} to be rejected (TS2322), got: ${bad
+            .map((d) => d.code)
+            .join(", ")}`,
+        );
+      });
+    }
+
+    it("works with Svelte 5 `mount(Foo, ...)` value usage and checks props", () => {
+      const diagnostics = typeCheckConsumer(
+        COMPONENT,
+        `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { value: "x" } });`,
+      );
+      assert.deepStrictEqual(
+        diagnostics.map((d) => d.code),
+        [],
+        `expected no diagnostics for mount(Foo, ...), got: ${diagnostics
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+          .join("; ")}`,
+      );
+    });
+
+    it("rejects wrong prop types via Svelte 5 `mount(Foo, ...)`", () => {
+      const diagnostics = typeCheckConsumer(
+        COMPONENT,
+        `import { mount } from "svelte";\nmount(Foo, { target: null as any, props: { value: 123 } });`,
+      );
+      assert.ok(
+        diagnostics.some((d) => d.code === 2322 || d.code === 2769),
+        `expected a prop type error from mount(Foo, ...), got: ${diagnostics
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+
+    it("resolves generic component props (type params as their constraint) for importers", () => {
+      const genericComponent = `<script lang="ts" generics="T extends string">
+  let { v }: { v: T } = $props();
+</script>
+<p>{v}</p>`;
+      const diagnostics = typeCheckConsumer(
+        genericComponent,
+        `const v: import("svelte").ComponentProps<typeof Foo>["v"] = 123;`,
+      );
+      assert.ok(
+        diagnostics.some((d) => d.code === 2322),
+        `expected TS2322 (number not assignable to string), got: ${diagnostics
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+  },
+);
+
+describe("imported component prop types, legacy (end-to-end type check)", () => {
+  const LEGACY_COMPONENT = `<script lang="ts">
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`;
+
+  it("resolves legacy `export let` props to their declared type for importers", () => {
+    // Svelte-4-style `ComponentProps<Foo>` uses `Foo` as a *type* (the instance),
+    // which the type-side alias provides on every version.
+    const diagnostics = typeCheckConsumer(
+      LEGACY_COMPONENT,
+      `const value: import("svelte").ComponentProps<Foo>["value"] = 123;`,
+    );
+    // `value` is `string`, so assigning a number must be a type error.
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("resolves legacy `$$Props` props to their declared type for importers", () => {
+    const legacyComponent = `<script lang="ts">
+  interface $$Props { value: string; count?: number }
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`;
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `const value: import("svelte").ComponentProps<Foo>["value"] = 123;`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("resolves legacy `$$Events` event types for importers", () => {
+    const legacyComponent = `<script lang="ts">
+  interface $$Events { foo: CustomEvent<number> }
+  export let value: string;
+</script>
+<p>{value}</p>`;
+    // `ComponentEvents<Foo>` uses `Foo` as a type. It must resolve (no TS2749)
+    // and carry the declared event detail type.
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `type E = import("svelte").ComponentEvents<Foo>;\nconst bad: E["foo"] = null as unknown as CustomEvent<string>;\nvoid bad;`,
+    );
+    assert.ok(
+      !diagnostics.some((d) => d.code === 2749),
+      "expected `Foo` to be usable as a type (no TS2749)",
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 for the wrong event detail type, got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("keeps `Foo` usable as a type even without `$$Events` (no regression)", () => {
+    const legacyComponent = `<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`;
+    // Without `$$Events`, events stay permissive (`any`), but `ComponentEvents<Foo>`
+    // must still resolve rather than failing with "Foo refers to a value".
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `type E = import("svelte").ComponentEvents<Foo>;\nconst e: E["anything"] = 1;\nvoid e;`,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      [],
+      `expected no diagnostics (events permissive, Foo usable as a type), got: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+        .join("; ")}`,
+    );
+  });
+
+  it("resolves a renamed reserved-word prop (`export { className as class }`) for importers", () => {
+    const legacyComponent = `<script lang="ts">
+  let className: string;
+  export { className as class };
+</script>
+<div class={className}></div>`;
+    // `class` resolves to `string`, so assigning a number must be a type error.
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `const c: import("svelte").ComponentProps<Foo>["class"] = 123;`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number not assignable to string) for the \`class\` prop, got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("accepts arbitrary extra attributes when the component reads `$$restProps`", () => {
+    const legacyComponent = `<script lang="ts">
+  export let value: string;
+  $$restProps;
+</script>
+<p>{value}</p>`;
+    // The open props type must accept extra attributes without a TS2353
+    // excess-property error, while still typing the declared prop.
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `const props: import("svelte").ComponentProps<Foo> = { value: "x", extra: 1 };\nvoid props;`,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      [],
+      `expected the extra attribute to be accepted, got: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+        .join("; ")}`,
+    );
+  });
+
+  it("still rejects a wrong-typed declared prop when props are open (`$$restProps`)", () => {
+    const legacyComponent = `<script lang="ts">
+  export let value: string;
+  $$restProps;
+</script>
+<p>{value}</p>`;
+    // Opening the props with an index signature must not weaken the declared prop.
+    const diagnostics = typeCheckConsumer(
+      legacyComponent,
+      `const v: import("svelte").ComponentProps<Foo>["value"] = 123;`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 for the wrong \`value\` type, got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+});
+
+describeLegacyClass(
+  "imported component value usage, legacy class (end-to-end type check)",
+  () => {
+    it("allows `new Foo(...)` on the legacy class component value", () => {
+      const legacyComponent = `<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`;
+      const diagnostics = typeCheckConsumer(
+        legacyComponent,
+        `const instance = new Foo({ target: null as any, props: { value: "x" } });\nvoid instance;`,
+      );
+      assert.deepStrictEqual(
+        diagnostics.map((d) => d.code),
+        [],
+        `expected no diagnostics for new Foo(...), got: ${diagnostics
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+          .join("; ")}`,
+      );
+    });
+
+    it("rejects a wrong prop value passed to `new Foo({ props: … })`", () => {
+      const legacyComponent = `<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`;
+      // `ComponentConstructorOptions<Props>` validates `props`, so a number where
+      // `value: string` is expected must error.
+      const diagnostics = typeCheckConsumer(
+        legacyComponent,
+        `const instance = new Foo({ target: null as any, props: { value: 123 } });\nvoid instance;`,
+      );
+      assert.ok(
+        diagnostics.some((d) => d.code === 2322 || d.code === 2769),
+        `expected a prop type error from new Foo({ props: … }), got: ${diagnostics
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+  },
+);
+
+// The suites above write the virtual code to `Foo.ts` and import `"./Foo"`,
+// which bypasses real module resolution. The suites below exercise the actual
+// importer path: a real `import Foo from "./Foo.svelte"` resolved through the
+// ts.sys hook's `X.svelte.ts` companion. The program includes Svelte's real
+// ambient `declare module '*.svelte'`, so these tests also prove the companion
+// wins over that permissive fallback.
+
+/**
+ * Type-check a consumer `.ts` that does a real `import Foo from "./Foo.svelte"`,
+ * routing the compiler host's `fileExists`/`readFile`/`getSourceFile` through a
+ * freshly-patched sys object (the same patch `installTsSysHook` applies to
+ * `ts.sys`). Returns the consumer's diagnostics.
+ *
+ * - `patch: false` skips the hook, so `./Foo.svelte` resolves to Svelte's
+ *   ambient module instead: the negative control for the ambient-shadow test.
+ * - `realCompanion` writes a real `Foo.svelte.ts` to disk to exercise the
+ *   conflict guard.
+ */
+function realResolutionDiagnostics(
+  componentSource: string,
+  consumerBody: string,
+  {
+    patch = true,
+    realCompanion,
+  }: { patch?: boolean; realCompanion?: string } = {},
+): ts.Diagnostic[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "real-resolve-"));
+  try {
+    const sveltePath = path.join(dir, "Foo.svelte");
+    fs.writeFileSync(sveltePath, componentSource, "utf-8");
+    if (realCompanion !== undefined) {
+      fs.writeFileSync(path.join(dir, "Foo.svelte.ts"), realCompanion, "utf-8");
+    }
+    const barPath = path.join(dir, "Bar.ts");
+    fs.writeFileSync(
+      barPath,
+      `import Foo from "./Foo.svelte";\n${consumerBody}\n`,
+      "utf-8",
+    );
+
+    // Base behavior is plain disk access; the hook adds interception on top.
+    const sys = {
+      readFile: (p: string): string | undefined => {
+        try {
+          return fs.readFileSync(p, "utf-8");
+        } catch {
+          return undefined;
+        }
+      },
+      fileExists: (p: string): boolean => fs.existsSync(p),
+    };
+    if (patch) {
+      _resetTranslationCacheForTesting();
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(sveltePath));
+    }
+
+    const compilerOptions: ts.CompilerOptions = {
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      types: [],
+      baseUrl: dir,
+      paths: { svelte: [svelteTypesPath] },
+    };
+    const host = ts.createCompilerHost(compilerOptions);
+    host.fileExists = (p) => sys.fileExists(p);
+    host.readFile = (p) => sys.readFile(p);
+    host.getSourceFile = (fileName, languageVersionOrOptions) => {
+      const text = sys.readFile(fileName);
+      return text === undefined
+        ? undefined
+        : ts.createSourceFile(fileName, text, languageVersionOrOptions);
+    };
+
+    const program = ts.createProgram([barPath], compilerOptions, host);
+    const all = [
+      ...program.getSemanticDiagnostics(),
+      ...program.getSyntacticDiagnostics(),
+    ];
+    return all.filter((d) => d.file?.fileName === barPath);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("ts.sys `X.svelte.ts` companion (unit)", () => {
+  beforeEach(() => {
+    _resetTranslationCacheForTesting();
+  });
+
+  it("claims existence of and serves the companion for a translatable `.svelte`", () => {
+    withTempSvelteFile(TS_SCRIPT, (sveltePath) => {
+      const companion = `${sveltePath}.ts`;
+      const sys = {
+        readFile: (p: string) => fs.readFileSync(p, "utf-8"),
+        fileExists: (p: string) => fs.existsSync(p),
+      };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(sveltePath));
+
+      assert.strictEqual(
+        sys.fileExists(companion),
+        true,
+        "companion must appear to exist so resolution reaches readFile",
+      );
+      assert.match(
+        sys.readFile(companion),
+        /declare const \$_svelteComponent\d+:/,
+        "companion read must return the component's virtual code",
+      );
+    });
+  });
+
+  it("does not claim a companion when there is no `.svelte` source", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ts-sys-hook-"));
+    try {
+      const companion = path.join(dir, "Missing.svelte.ts");
+      const sys = {
+        readFile: (p: string): string | undefined => {
+          try {
+            return fs.readFileSync(p, "utf-8");
+          } catch {
+            return undefined;
+          }
+        },
+        fileExists: (p: string) => fs.existsSync(p),
+      };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(
+        makeParserOptions(path.join(dir, "Missing.svelte")),
+      );
+
+      assert.strictEqual(sys.fileExists(companion), false);
+      assert.strictEqual(sys.readFile(companion), undefined);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stays a complete passthrough when a real `X.svelte.ts` exists (conflict guard)", () => {
+    withTempSvelteFile(TS_SCRIPT, (sveltePath) => {
+      const companion = `${sveltePath}.ts`;
+      const realContent = "export const runesModuleMarker = 1;\n";
+      fs.writeFileSync(companion, realContent, "utf-8");
+      const sys = {
+        readFile: (p: string) => fs.readFileSync(p, "utf-8"),
+        fileExists: (p: string) => fs.existsSync(p),
+      };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(sveltePath));
+
+      // The collision is deliberate here, so the warning is expected.
+      withoutHookWarnings(() => {
+        // The real runes module must win, untouched, not the virtual code.
+        assert.strictEqual(sys.fileExists(companion), true);
+        assert.strictEqual(sys.readFile(companion), realContent);
+
+        // Once the real file is gone, the virtual companion takes over.
+        fs.rmSync(companion);
+        assert.strictEqual(sys.fileExists(companion), true);
+        assert.match(
+          sys.readFile(companion),
+          /declare const \$_svelteComponent\d+:/,
+        );
+      });
+    });
+  });
+});
+
+describe("ts.sys companion name collision warning", () => {
+  beforeEach(() => {
+    // Also re-arms the once-per-process warning flag.
+    _resetTranslationCacheForTesting();
+  });
+
+  it("warns exactly once when a real `X.svelte.ts` shadows `X.svelte`", () => {
+    withTempSvelteFile(TS_SCRIPT, (sveltePath) => {
+      const companion = `${sveltePath}.ts`;
+      fs.writeFileSync(companion, "export const x = 1;\n", "utf-8");
+      // A second colliding pair, to prove the flag is per-process not per-file.
+      const otherSvelte = path.join(path.dirname(sveltePath), "Other.svelte");
+      fs.writeFileSync(otherSvelte, TS_SCRIPT, "utf-8");
+      fs.writeFileSync(`${otherSvelte}.ts`, "export const y = 1;\n", "utf-8");
+
+      const sys = {
+        readFile: (p: string) => fs.readFileSync(p, "utf-8"),
+        fileExists: (p: string) => fs.existsSync(p),
+      };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(sveltePath));
+
+      const warnings = captureWarnings(() => {
+        // Several probes of both colliding pairs, through both patched methods.
+        sys.fileExists(companion);
+        sys.readFile(companion);
+        sys.fileExists(companion);
+        sys.fileExists(`${otherSvelte}.ts`);
+        sys.readFile(`${otherSvelte}.ts`);
+      });
+
+      assert.strictEqual(
+        warnings.length,
+        1,
+        `expected exactly one warning, got: ${JSON.stringify(warnings)}`,
+      );
+      assert.ok(
+        warnings[0].includes(companion) && warnings[0].includes(sveltePath),
+        `expected the colliding paths in the warning, got: ${warnings[0]}`,
+      );
+      assert.ok(
+        warnings[0].includes("svelte/no-conflicting-module-names"),
+        `expected the lint rule name in the warning, got: ${warnings[0]}`,
+      );
+
+      // The guard itself is unchanged: the real module is served untouched.
+      assert.strictEqual(sys.fileExists(companion), true);
+      assert.strictEqual(sys.readFile(companion), "export const x = 1;\n");
+    });
+  });
+
+  it("does not warn for a `.svelte.ts` module with no `.svelte` sibling", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ts-sys-hook-"));
+    try {
+      const lone = path.join(dir, "store.svelte.ts");
+      fs.writeFileSync(lone, "export const count = 1;\n", "utf-8");
+      const sys = {
+        readFile: (p: string) => fs.readFileSync(p, "utf-8"),
+        fileExists: (p: string) => fs.existsSync(p),
+      };
+      _patchTsSysForTesting(sys);
+      rememberParserOptions(makeParserOptions(path.join(dir, "Any.svelte")));
+
+      const warnings = captureWarnings(() => {
+        sys.fileExists(lone);
+        sys.readFile(lone);
+      });
+
+      assert.deepStrictEqual(
+        warnings,
+        [],
+        `expected no warning without a .svelte sibling, got: ${JSON.stringify(warnings)}`,
+      );
+      assert.strictEqual(sys.readFile(lone), "export const count = 1;\n");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describeSvelte5(
+  "imported component prop types via real `.svelte` resolution (runes, e2e)",
+  () => {
+    const RUNES_COMPONENT = `<script lang="ts">
+  let { value, count = 0 }: { value: string; count?: number } = $props();
+</script>
+<p>{value}{count}</p>`;
+
+    const PROBE_COMPONENT = `<script lang="ts">
+  let { value, count = 0 } = $props();
+</script>
+<p>{value}{count}</p>`;
+
+    it("rejects a wrong-typed prop through a real `import Foo from './Foo.svelte'`", () => {
+      const diagnostics = realResolutionDiagnostics(
+        RUNES_COMPONENT,
+        `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123; void value;`,
+      );
+      assert.ok(
+        diagnostics.some((d) => d.code === 2322),
+        `expected TS2322 through real resolution, got: ${diagnostics
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+
+    it("accepts a correctly-typed prop through real resolution", () => {
+      const diagnostics = realResolutionDiagnostics(
+        RUNES_COMPONENT,
+        `const value: import("svelte").ComponentProps<typeof Foo>["value"] = "ok"; void value;`,
+      );
+      assert.deepStrictEqual(
+        diagnostics.map((d) => d.code),
+        [],
+        `expected no diagnostics, got: ${diagnostics
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+          .join("; ")}`,
+      );
+    });
+
+    // The `typeof`-probe inference relies on a `const` value declaration, which
+    // only survives when the companion is served as an implementation file, not
+    // a declaration file.
+    it("preserves un-annotated `$props()` probe inference through real resolution", () => {
+      const bad = realResolutionDiagnostics(
+        PROBE_COMPONENT,
+        `const count: import("svelte").ComponentProps<typeof Foo>["count"] = "x"; void count;`,
+      );
+      assert.ok(
+        bad.some((d) => d.code === 2322),
+        `expected the probe-inferred number prop to reject a string, got: ${bad
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+      const good = realResolutionDiagnostics(
+        PROBE_COMPONENT,
+        `const count: import("svelte").ComponentProps<typeof Foo>["count"] = 1; void count;`,
+      );
+      assert.deepStrictEqual(
+        good.map((d) => d.code),
+        [],
+        `expected the probe-inferred number prop to accept a number, got: ${good
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+          .join("; ")}`,
+      );
+    });
+
+    it("resolves the companion, not Svelte's ambient `declare module '*.svelte'`", () => {
+      // Negative control: without the hook, `./Foo.svelte` resolves to Svelte's
+      // ambient module, whose props are permissive, so the import still resolves
+      // (no TS2307) but a wrong-typed prop is not caught (no TS2322).
+      const ambient = realResolutionDiagnostics(
+        RUNES_COMPONENT,
+        `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123; void value;`,
+        { patch: false },
+      );
+      assert.ok(
+        !ambient.some((d) => d.code === 2307),
+        "the ambient `declare module '*.svelte'` should resolve the import",
+      );
+      assert.ok(
+        !ambient.some((d) => d.code === 2322),
+        "the ambient module's props are permissive, so no type error is expected",
+      );
+      // With the hook, the companion's `value: string` rejects a number, an
+      // error the ambient's permissive props could never produce.
+      const hooked = realResolutionDiagnostics(
+        RUNES_COMPONENT,
+        `const value: import("svelte").ComponentProps<typeof Foo>["value"] = 123; void value;`,
+      );
+      assert.ok(
+        hooked.some((d) => d.code === 2322),
+        `expected the companion prop type to win over the ambient, got: ${hooked
+          .map((d) => d.code)
+          .join(", ")}`,
+      );
+    });
+  },
+);
+
+describe("imported component prop types via real `.svelte` resolution (legacy, e2e)", () => {
+  const LEGACY_COMPONENT = `<script lang="ts">
+  export let value: string;
+  export let count = 0;
+</script>
+<p>{value}{count}</p>`;
+
+  it("resolves legacy `export let` props through a real `.svelte` import", () => {
+    // Svelte-4-style `ComponentProps<Foo>` uses `Foo` as a type, provided on
+    // every version by the companion's type-side alias.
+    const diagnostics = realResolutionDiagnostics(
+      LEGACY_COMPONENT,
+      `const value: import("svelte").ComponentProps<Foo>["value"] = 123; void value;`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 through real resolution, got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("resolves legacy `$$Events` event types through a real `.svelte` import", () => {
+    const eventsComponent = `<script lang="ts">
+  interface $$Events { foo: CustomEvent<number> }
+  export let value: string;
+</script>
+<p>{value}</p>`;
+    // `ComponentEvents<Foo>` uses `Foo` as a type, provided by the companion's
+    // type-side alias, so it must resolve (no TS2749 "Foo refers to a value").
+    const diagnostics = realResolutionDiagnostics(
+      eventsComponent,
+      `type E = import("svelte").ComponentEvents<Foo>;\nconst bad: E["foo"] = null as unknown as CustomEvent<string>;\nvoid bad;`,
+    );
+    assert.ok(
+      !diagnostics.some((d) => d.code === 2749),
+      "expected `Foo` to be usable as a type through real resolution (no TS2749)",
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 for the wrong event detail type, got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("resolves to a user-authored default export instead of the synthetic one", () => {
+    const userDefault = `<script lang="ts" context="module">
+  export default 42;
+</script>
+<script lang="ts">
+  export let value: string;
+</script>
+<p>{value}</p>`;
+    // `Foo` is the user's `export default 42` (a number), so assigning it to a
+    // string must error, proving resolution reached the user's own default.
+    const diagnostics = realResolutionDiagnostics(
+      userDefault,
+      `const s: string = Foo; void s;`,
+    );
+    assert.ok(
+      diagnostics.some((d) => d.code === 2322),
+      `expected TS2322 (number default not assignable to string), got: ${diagnostics
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
+  });
+
+  it("stays a passthrough to a real `X.svelte.ts` next to `X.svelte` (conflict guard)", () => {
+    // A genuine runes module `Foo.svelte.ts` on disk must win: `Foo.real` (its
+    // own export) resolves, while the synthetic virtual export never shadows it.
+    const realCompanion = `const _c: { real: string } = { real: "" };\nexport default _c;\n`;
+    // The collision is deliberate here, so the warning is expected.
+    const ok = withoutHookWarnings(() =>
+      realResolutionDiagnostics(
+        LEGACY_COMPONENT,
+        `const r: string = Foo.real; void r;`,
+        { realCompanion },
+      ),
+    );
+    assert.deepStrictEqual(
+      ok.map((d) => d.code),
+      [],
+      `expected the real .svelte.ts to be used untouched, got: ${ok
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+        .join("; ")}`,
+    );
+    const bad = withoutHookWarnings(() =>
+      realResolutionDiagnostics(
+        LEGACY_COMPONENT,
+        `const n: number = Foo.real; void n;`,
+        { realCompanion },
+      ),
+    );
+    assert.ok(
+      bad.some((d) => d.code === 2322),
+      `expected TS2322 from the real module's \`real: string\`, got: ${bad
+        .map((d) => d.code)
+        .join(", ")}`,
+    );
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **🚧 Work In Progress — Alpha. Do not merge.**
> Authored by Claude Code (AI), published as a draft for early review only. Behavior/API may change or be dropped.

## Problem

`Foo.svelte`'s virtual code exposed no default export, so an importer's `typeof Foo` resolved to `any` and every prop collapsed to `any`.

## Approach

Append a synthetic default export as a value/type pair, so the component works both as a value (`typeof Foo`, `mount(Foo, …)`, `new Foo(…)`) and as a type (`ComponentEvents<Foo>`, Svelte-4-style `ComponentProps<Foo>`):

```ts
declare const $_svelteComponent1: import('svelte').Component<{ value: string; count?: number }>;
type $_svelteComponent1 = import('svelte').SvelteComponent<{ value: string; count?: number }, Record<string, any>, Record<string, any>>;
export { $_svelteComponent1 as default };
```

Props are recovered without a `svelte2tsx` dependency: in runes mode from a `$props()` annotation / `as` / `satisfies`, or from an un-annotated destructuring via a `typeof` probe; in legacy mode from `$$Props`, else from `export let`. `$$Events` / `$$Slots` type events and slots when declared. Recovery is scoped to the instance script, a user-authored default export suppresses the synthetic one, and the fallback is `Record<string, any>`. Type names are chosen by the *installed* Svelte version, since Svelte 3/4 have no `Component` — that is what broke the old stack's CI.

The synthetic statements are removed again in the restore pass, so the linted file's AST and `scopeManager` are byte-for-byte unchanged.

Emitting the export is not enough on its own: TypeScript cannot resolve a specifier ending in `.svelte` and silently falls back to Svelte's ambient `declare module '*.svelte'`, leaving the feature inert. The experimental `ts.sys` hook (`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`) therefore also serves the virtual code at the `X.svelte.ts` companion path TypeScript probes. No `tsconfig` changes are needed and a real `X.svelte.ts` on disk always wins; the hook warns once when it sees such a collision and points at `svelte/no-conflicting-module-names`.

Supersedes #905–#911, which are consolidated here.

## Closes

Both only with the experimental hook enabled, since that is what makes the export observable to importers.

- Closes #915 — a type exported from another component's `<script module>` resolved as an "error" type. Repro goes from `TS2307` + `any` to `string`.
- sveltejs/eslint-plugin-svelte#1303 — `ComponentProps<typeof Other>['a']` resolved as `any`. Verified it really resolves to `number`, not merely silenced (`a + 1` and `a.toFixed(2)` probes are clean). Needs closing by hand, since keywords do not work across repositories.

## Verified

Full suite green on the CI matrix (Svelte 5 / 4 / 3), lint and `build:tsc` clean. The AST/scope invariance suite confirms restore is byte-perfect, and end-to-end `tsc` tests cover both producer and consumer files. Implemented and adversarially reviewed by a multi-agent process across three lenses (type semantics on 3/4/5, restore/scope invariance, test quality incl. mutation testing).

## Limitations

- Un-annotated props with no default stay `any`, as in svelte2tsx.
- Slot types come from a declared `$$Slots` only; `<slot name=… prop=…>` elements are not analyzed, so `let:` variables stay `any` (#394).
- Instance exports (`export const` / `export function`) are not emitted, so `bind:this` members stay `any` (sveltejs/eslint-plugin-svelte#1150).
- ES2022 string-literal export names (`export { a as "data-x" }`) fall back to the permissive type.
- `$$props` / `$$restProps` components use an open props type, over-accepting by design.
- Importer-side effect is gated on the experimental hook; the synthetic export itself is always emitted and fully restored.
- A component with a same-named runes module (`Foo.svelte` + `Foo.svelte.ts`) gets no prop types, because the real module must win.
