### PR TITLE
feat: statically resolve the svelte config from the sveltekit() plugin options in vite configs

### DIFF
--- a/.changeset/afraid-frogs-search.md
+++ b/.changeset/afraid-frogs-search.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: statically resolve the svelte config from the `sveltekit()` plugin options in vite configs

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ export default [
 ];
 ```
 
-If `parserOptions.svelteConfig` is not set, the parser attempts to statically read some config from `svelte.config.js`.
+If `parserOptions.svelteConfig` is not set, the parser attempts to statically read some config from the options passed to the `sveltekit()` plugin in a vite config (where SvelteKit 3 projects configure Svelte), falling back to `svelte.config.js`.
 
 ### parserOptions.svelteFeatures
 

--- a/src/svelte-config/index.ts
+++ b/src/svelte-config/index.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import { parseConfig } from "./parser.js";
+import { parseConfig, parseViteConfig } from "./parser.js";
 import type * as Compiler from "svelte/compiler";
 
 export type SvelteConfig = {
@@ -96,9 +96,17 @@ export function resolveSvelteConfigFromOption(
   return resolveSvelteConfig(options?.filePath);
 }
 
+const VITE_CONFIG_FILE_NAMES = [
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.ts",
+  "vite.config.mts",
+];
+
 /**
- * Resolves `svelte.config.js`.
- * It searches the parent directories of the given file to find `svelte.config.js`,
+ * Resolves the svelte config.
+ * It searches the parent directories of the given file for a vite config that
+ * passes options to the `sveltekit()` plugin, or a `svelte.config.js`,
  * and returns the static analysis result for it.
  */
 function resolveSvelteConfig(
@@ -109,41 +117,48 @@ function resolveSvelteConfig(
     if (typeof process === "undefined") return null;
     cwd = process.cwd();
   }
-  const configFilePath = findConfigFilePath(cwd);
-  if (!configFilePath) return null;
-
-  if (caches.has(configFilePath)) {
-    return caches.get(configFilePath) || null;
-  }
-
-  const code = fs.readFileSync(configFilePath, "utf8");
-  const config = parseConfig(code);
-  caches.set(configFilePath, config);
-  return config;
-}
-
-/**
- * Searches from the current working directory up until finding the config filename.
- * @param {string} cwd The current working directory to search from.
- * @returns {string|undefined} The file if found or `undefined` if not.
- */
-function findConfigFilePath(cwd: string) {
   let directory = path.resolve(cwd);
   const { root } = path.parse(directory);
   const stopAt = path.resolve(directory, root);
   while (directory !== stopAt) {
+    // Options passed to `sveltekit()` win: SvelteKit ignores svelte.config.js when they are set.
+    for (const name of VITE_CONFIG_FILE_NAMES) {
+      const viteTarget = path.resolve(directory, name);
+      if (isFile(viteTarget)) {
+        const config = parseWithCache(viteTarget, parseViteConfig);
+        if (config) return config;
+        break;
+      }
+    }
     const target = path.resolve(directory, "svelte.config.js");
-    const stat = fs.existsSync(target)
-      ? fs.statSync(target, {
-          throwIfNoEntry: false,
-        })
-      : null;
-    if (stat?.isFile()) {
-      return target;
+    if (isFile(target)) {
+      return parseWithCache(target, parseConfig);
     }
     const next = path.dirname(directory);
     if (next === directory) break;
     directory = next;
   }
   return null;
+}
+
+function parseWithCache(
+  filePath: string,
+  parse: (code: string) => SvelteConfig | null,
+): SvelteConfig | null {
+  if (caches.has(filePath)) {
+    return caches.get(filePath) || null;
+  }
+  const code = fs.readFileSync(filePath, "utf8");
+  const config = parse(code);
+  caches.set(filePath, config);
+  return config;
+}
+
+function isFile(target: string): boolean {
+  const stat = fs.existsSync(target)
+    ? fs.statSync(target, {
+        throwIfNoEntry: false,
+      })
+    : null;
+  return stat?.isFile() ?? false;
 }

--- a/src/svelte-config/parser.ts
+++ b/src/svelte-config/parser.ts
@@ -7,6 +7,45 @@ import { findVariable } from "../scope/index.js";
 import { getESLintScope } from "../parser/eslint-scope.js";
 
 export function parseConfig(code: string): SvelteConfig | null {
+  const { ast, scopeManager } = parseModule(code);
+  return parseAst(ast, scopeManager);
+}
+
+/**
+ * Statically extracts the svelte config from the object passed to
+ * the `sveltekit()` plugin call in a vite config.
+ */
+export function parseViteConfig(code: string): SvelteConfig | null {
+  let ast: ESTree.Program, scopeManager: Scope.ScopeManager;
+  try {
+    ({ ast, scopeManager } = parseModule(code));
+  } catch {
+    // vite configs may be TypeScript files containing syntax espree cannot parse
+    return null;
+  }
+  let config: SvelteConfig | null = null;
+  traverseNodes(ast, {
+    enterNode(node) {
+      if (config != null || node.type !== "CallExpression") return;
+      const callee = node.callee;
+      if (callee.type !== "Identifier") return;
+      if (!isKitPluginImport(callee, scopeManager)) return;
+      const arg = node.arguments[0];
+      // a bare `sveltekit()` means the config lives in svelte.config.js
+      if (!arg || arg.type === "SpreadElement") return;
+      config = parsePluginOptionsExpression(arg, scopeManager);
+    },
+    leaveNode() {
+      /* do nothing */
+    },
+  });
+  return config;
+}
+
+function parseModule(code: string): {
+  ast: ESTree.Program;
+  scopeManager: Scope.ScopeManager;
+} {
   const espree = getEspree();
   const ast = espree.parse(code, {
     range: true,
@@ -32,7 +71,43 @@ export function parseConfig(code: string): SvelteConfig | null {
     sourceType: "module",
     fallback: getFallbackKeys,
   });
-  return parseAst(ast, scopeManager);
+  return { ast, scopeManager };
+}
+
+/** Checks that the callee resolves to the `sveltekit` import from `@sveltejs/kit/vite`. */
+function isKitPluginImport(
+  node: ESTree.Identifier,
+  scopeManager: Scope.ScopeManager,
+): boolean {
+  const defs = findVariable(scopeManager, node)?.defs;
+  if (defs?.length !== 1) return false;
+  const def = defs[0];
+  return (
+    def.type === "ImportBinding" &&
+    def.node.type === "ImportSpecifier" &&
+    def.node.imported.type === "Identifier" &&
+    def.node.imported.name === "sveltekit" &&
+    def.parent.source.value === "@sveltejs/kit/vite"
+  );
+}
+
+/**
+ * The plugin options mirror svelte.config.js except that kit options
+ * sit at the top level instead of under a `kit` key.
+ */
+function parsePluginOptionsExpression(
+  node: ESTree.Expression,
+  scopeManager: Scope.ScopeManager,
+): SvelteConfig {
+  const result = parseSvelteConfigExpression(node, scopeManager);
+  const evaluated = evaluateExpression(node, scopeManager);
+  if (evaluated?.type === EvaluatedType.object) {
+    const files = evaluated.getProperty("files")?.getStatic();
+    if (files?.value != null) {
+      result.kit = { files: files.value as never };
+    }
+  }
+  return result;
 }
 
 function parseAst(

--- a/tests/src/svelte-config/parser.ts
+++ b/tests/src/svelte-config/parser.ts
@@ -1,5 +1,8 @@
 import assert from "assert";
-import { parseConfig } from "../../../src/svelte-config/parser.js";
+import {
+  parseConfig,
+  parseViteConfig,
+} from "../../../src/svelte-config/parser.js";
 
 describe("parseConfig", () => {
   const testCases = [
@@ -70,6 +73,94 @@ describe("parseConfig", () => {
   for (const { code, output } of testCases) {
     it(code, () => {
       assert.deepStrictEqual(parseConfig(code), output);
+    });
+  }
+});
+
+describe("parseViteConfig", () => {
+  const testCases = [
+    {
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        import { defineConfig } from 'vite';
+        export default defineConfig({ plugins: [sveltekit({ compilerOptions: { runes: true } })] });
+        `,
+      output: { compilerOptions: { runes: true } },
+    },
+    {
+      // a bare sveltekit() means the config lives in svelte.config.js
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        export default { plugins: [sveltekit()] };
+        `,
+      output: null,
+    },
+    {
+      // options were passed but cannot be analyzed: svelte.config.js is
+      // still ignored by SvelteKit, so an empty config wins over falling back
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        import { options } from './config.js';
+        export default { plugins: [sveltekit(options)] };
+        `,
+      output: {},
+    },
+    {
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        const options = { compilerOptions: { runes: false } };
+        export default { plugins: [sveltekit(options)] };
+        `,
+      output: { compilerOptions: { runes: false } },
+    },
+    {
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        export default { plugins: [sveltekit({ files: { routes: 'src/custom' } })] };
+        `,
+      output: { kit: { files: { routes: "src/custom" } } },
+    },
+    {
+      code: `
+        import { sveltekit as kit } from '@sveltejs/kit/vite';
+        export default { plugins: [kit({ compilerOptions: { runes: true } })] };
+        `,
+      output: { compilerOptions: { runes: true } },
+    },
+    {
+      code: `
+        import { sveltekit } from 'not-kit';
+        export default { plugins: [sveltekit({ compilerOptions: { runes: true } })] };
+        `,
+      output: null,
+    },
+    {
+      code: `
+        import { somePlugin } from 'some-plugin';
+        export default { plugins: [somePlugin()] };
+        `,
+      output: null,
+    },
+    {
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        const plugins = [[sveltekit({ compilerOptions: { runes: true } })]];
+        export default { plugins };
+        `,
+      output: { compilerOptions: { runes: true } },
+    },
+    {
+      code: `
+        import { sveltekit } from '@sveltejs/kit/vite';
+        import { defineConfig, type UserConfig } from 'vite';
+        export default defineConfig({ plugins: [sveltekit({ compilerOptions: { runes: true } })] });
+        `,
+      output: null,
+    },
+  ];
+  for (const { code, output } of testCases) {
+    it(code, () => {
+      assert.deepStrictEqual(parseViteConfig(code), output);
     });
   }
 });


### PR DESCRIPTION
sveltejs/kit#16671: the parser now statically reads the options passed to `sveltekit()` in the vite config, falling back to `svelte.config.js` when none are passed. Anything the static analysis can't handle degrades to no config, same as today.
