### PR TITLE
fix: make ts.sys hook effective when the TS program is created before the first .svelte parse

### DIFF
--- a/.changeset/shiny-pears-tell.md
+++ b/.changeset/shiny-pears-tell.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: make the experimental `ts.sys` hook work when the TS program is created before the first `.svelte` parse

--- a/src/ts-sys-hook.ts
+++ b/src/ts-sys-hook.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { createRequire } from "module";
 import type { NormalizedParserOptions } from "./parser/parser-options.js";
+import { normalizeParserOptions } from "./parser/parser-options.js";
 import { svelteToVirtualTypeScript } from "./parser/svelte-to-virtual-ts.js";
 import { loadNewestModule } from "./utils/cjs-module.js";
 
@@ -24,6 +25,8 @@ interface TranslationEntry {
   // `null` means "no virtual translation at this mtime" — a negative cache
   // so JS-only `.svelte` files don't pay a full Svelte parse on every read.
   virtualCode: string | null;
+  // Translated with fallback options before the first `.svelte` parse.
+  provisional: boolean;
 }
 
 interface TsLike {
@@ -35,6 +38,8 @@ interface TsLike {
 const translations = new Map<string, TranslationEntry>();
 const patchedSysObjects = new WeakSet();
 let activeParserOptions: NormalizedParserOptions | null = null;
+let fallbackParserOptions: NormalizedParserOptions | null | undefined =
+  undefined;
 let installed = false;
 let needsParseTimeRescan = false;
 let parserOptionsInspected = false;
@@ -48,7 +53,15 @@ function warn(msg: string): void {
 
 /** Called from `parseForESLint` so translation has the user's parser config. */
 export function rememberParserOptions(options: NormalizedParserOptions): void {
+  const hadOptions = activeParserOptions !== null;
   activeParserOptions = options;
+
+  // Drop fallback translations so they are redone with the real options.
+  if (!hadOptions) {
+    for (const [filePath, entry] of translations) {
+      if (entry.provisional) translations.delete(filePath);
+    }
+  }
 
   if (installed && !parserOptionsInspected) {
     parserOptionsInspected = true;
@@ -100,10 +113,12 @@ export function primeTranslationCache(
   // Skip the stat + write if on-demand translation already cached a positive
   // entry — the prime is redundant when ts.sys read the file before ESLint did.
   const existing = translations.get(filePath);
-  if (existing && existing.virtualCode !== null) return;
+  if (existing && existing.virtualCode !== null && !existing.provisional) {
+    return;
+  }
   const mtimeMs = statMtimeMs(filePath);
   if (mtimeMs === null) return;
-  translations.set(filePath, { mtimeMs, virtualCode });
+  translations.set(filePath, { mtimeMs, virtualCode, provisional: false });
   primeStoredCount++;
 }
 
@@ -123,8 +138,23 @@ function readUtf8(filePath: string): string | null {
   }
 }
 
+/** Fallback options for translations requested before the first `.svelte` parse. */
+function getFallbackParserOptions(): NormalizedParserOptions | null {
+  if (fallbackParserOptions !== undefined) return fallbackParserOptions;
+  try {
+    fallbackParserOptions = normalizeParserOptions({
+      parser: loadNewestModule("@typescript-eslint/parser"),
+    });
+  } catch {
+    fallbackParserOptions = null;
+  }
+  return fallbackParserOptions;
+}
+
 function translateOnDemand(filePath: string): string | null {
-  if (!activeParserOptions) return null;
+  const parserOptions = activeParserOptions ?? getFallbackParserOptions();
+  if (!parserOptions) return null;
+  const provisional = activeParserOptions === null;
 
   const mtimeMs = statMtimeMs(filePath);
   if (mtimeMs === null) return null;
@@ -134,17 +164,17 @@ function translateOnDemand(filePath: string): string | null {
 
   const svelteSource = readUtf8(filePath);
   if (svelteSource === null) {
-    translations.set(filePath, { mtimeMs, virtualCode: null });
+    translations.set(filePath, { mtimeMs, virtualCode: null, provisional });
     return null;
   }
 
   const virtualCode = svelteToVirtualTypeScript(
     filePath,
     svelteSource,
-    activeParserOptions,
+    parserOptions,
   );
   // Store the outcome — including `null` — to negative-cache failed translations.
-  translations.set(filePath, { mtimeMs, virtualCode });
+  translations.set(filePath, { mtimeMs, virtualCode, provisional });
   return virtualCode;
 }
 
@@ -242,6 +272,7 @@ export function installTsSysHook(): void {
 export function _resetTranslationCacheForTesting(): void {
   translations.clear();
   activeParserOptions = null;
+  fallbackParserOptions = undefined;
   needsParseTimeRescan = false;
 }
 

--- a/tests/src/ts-sys-hook.ts
+++ b/tests/src/ts-sys-hook.ts
@@ -153,11 +153,34 @@ describe("ts.sys.readFile hook wiring", () => {
     });
   });
 
-  it("does nothing before rememberParserOptions sets options", () => {
+  it("translates with fallback options before rememberParserOptions is called", () => {
     withTempSvelteFile(TS_SCRIPT, (filePath) => {
       const sys = { readFile: (p: string) => fs.readFileSync(p, "utf-8") };
       _patchTsSysForTesting(sys);
 
+      const result = sys.readFile(filePath);
+      assert.match(
+        result,
+        /let count: number/,
+        "expected the virtual TS shim even before options are known",
+      );
+    });
+  });
+
+  it("re-translates fallback results once real options are known", () => {
+    withTempSvelteFile(TS_SCRIPT, (filePath) => {
+      const sys = { readFile: (p: string) => fs.readFileSync(p, "utf-8") };
+      _patchTsSysForTesting(sys);
+
+      const before = sys.readFile(filePath);
+      assert.match(before, /let count: number/);
+
+      // These options have no TS parser, so re-translation fails and the
+      // read falls through to raw source — proving the fallback entry was
+      // dropped rather than served from cache.
+      rememberParserOptions(
+        normalizeParserOptions({ filePath, ecmaVersion: 2024 }),
+      );
       assert.strictEqual(sys.readFile(filePath), TS_SCRIPT);
     });
   });


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1552

I created this PR using Fable 5.

## What

Fixes an ordering bug that made the experimental `ts.sys.readFile` hook (`SVELTE_ESLINT_PARSER_EXPERIMENTAL_TS_SYS_HOOK=1`) ineffective in real-world mixed TS/Svelte projects. This is the root cause of the slowness reported in sveltejs/eslint-plugin-svelte#1552 (Immich).

## Background: why Immich lint is slow

With type-aware lint (`parserOptions.project`), typescript-estree shares one watch program per tsconfig and keeps its `TypeChecker` warm as long as the code being linted hashes to the same content the program read from disk. For `.svelte` files the parser feeds typescript-estree **virtual TS code** that never matches the raw on-disk Svelte source, so [the hash check in `getWatchProgramsForProjects`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts) fires a file-watch invalidation and **rebuilds the program for every single `.svelte` file**, discarding the checker cache each time (~0.5–1s CPU per file in Immich, ×412 files).

The ts.sys hook was built to fix exactly this: it makes the program read translated virtual TS for `.svelte` paths, so hashes match and the program is reused.

## The bug

`translateOnDemand` required `activeParserOptions`, which is only set by `rememberParserOptions` during the first `.svelte` parse. But with `eslint .` the first type-aware file is usually a plain `.ts` file (in Immich: `src/hooks.server.ts`), and the shared program is created **at that moment** — before any `.svelte` parse. The hook then returns raw Svelte source for every `.svelte` path, and 406/412 Immich components still invalidated per-file. Measured on Immich `web/` (`eslint . --max-warnings 0 --concurrency 6`, M-series laptop):

| configuration | wall | CPU |
|---|---|---|
| baseline (no hook) | 94.5s | 554s |
| hook enabled, **before this fix** | 88.2s | 538s |
| hook enabled, **with this fix** | **27.1s** | **119s** |

(On slower machines the baseline is reported as “several minutes to half an hour”, so the absolute win is much larger there.)

## The fix

- When a translation is requested before any `.svelte` parse, fall back to a minimal parser config (`@typescript-eslint/parser` resolved via `loadNewestModule`) instead of giving up.
- Entries translated with the fallback are marked `provisional`; once the user's real parser options arrive they are dropped so the next read re-translates with the real configuration, and `primeTranslationCache` now overwrites provisional entries with the parse-path shim (the ground truth typescript-estree hashes against).

Verified on Immich that hash mismatches drop to **0** even when a `.ts` file is linted first, and lint results are unchanged.
